### PR TITLE
Put ResearchStudyCollection under Entity

### DIFF
--- a/src/bdchm/schema/bdchm.yaml
+++ b/src/bdchm/schema/bdchm.yaml
@@ -281,7 +281,7 @@ classes:
         description: When a period of time ended.
 
   ResearchStudyCollection:
-    tree_root: true
+    is_a: Entity
     description: >-
       A holder for ResearchStudy objects
     attributes:

--- a/src/bdchm/schema/bdchm.yaml
+++ b/src/bdchm/schema/bdchm.yaml
@@ -282,6 +282,7 @@ classes:
 
   ResearchStudyCollection:
     is_a: Entity
+    tree_root: true
     description: >-
       A holder for ResearchStudy objects
     attributes:


### PR DESCRIPTION
It was the only class not under Entity, which has been annoying for the [interactive docs app](https://sigfried.github.io/dynamic-model-var-docs/?sections=lc%7Ere%7Erc%7Ert&hover=0). With this change, instead of two "Classes" we'll have 51 "Entities."

<img width="207" height="118" alt="image" src="https://github.com/user-attachments/assets/7cf24f81-360a-4266-bd6d-00a58b82c780" />
