### PR TITLE
Punch-list cleanup from the poetry→uv / CI / lint PRs

### DIFF
--- a/.github/workflows/deploy_bdchm_docs.yml
+++ b/.github/workflows/deploy_bdchm_docs.yml
@@ -23,14 +23,11 @@ jobs:
 
       - name: Install uv.
         uses: astral-sh/setup-uv@v5
-
-      - name: Set up Python.
-        uses: actions/setup-python@v5
         with:
           python-version: '3.12'
 
       - name: Install dependencies.
-        run: uv sync
+        run: uv sync --locked
 
       - name: Build documentation.
         run: |

--- a/.github/workflows/main.yaml
+++ b/.github/workflows/main.yaml
@@ -43,7 +43,7 @@ jobs:
           python-version: ${{ matrix.python-version }}
 
       - name: Install dependencies
-        run: uv sync
+        run: uv sync --locked
 
       - name: Run tests
         run: make test

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -14,7 +14,7 @@ repos:
       - id: trailing-whitespace
 
   - repo: https://github.com/astral-sh/ruff-pre-commit
-    rev: v0.11.13
+    rev: v0.15.13
     hooks:
       - id: ruff-check
         args: [--fix, --exit-non-zero-on-fix]

--- a/Makefile
+++ b/Makefile
@@ -105,7 +105,8 @@ update-template:
 
 # todo: consider pinning to template
 update-linkml:
-	uv add --dev linkml@latest
+	uv lock --upgrade-package linkml
+	uv sync
 
 # EXPERIMENTAL
 create-data-harmonizer:

--- a/README.md
+++ b/README.md
@@ -21,15 +21,24 @@ Please read the [Collaboration Guide](CONTRIBUTING.md) before contributing.
 
 <details>
 
+This project uses [uv](https://docs.astral.sh/uv/) for dependency
+management and requires Python >= 3.10.
+
 To setup a local development environment:
 
 * clone the repository
 * change directories to the model repository using `cd bdchm`
-* install all of the dependencies using `poetry install`
-* enter the poetry environment using `poetry shell`
-* use the `make` command to generate project artefacts:
+* install all dependencies (including dev tooling) with `uv sync`
+* use the `make` command to generate project artefacts (targets run
+  inside the uv environment automatically):
   * `make gendoc`: generates documentation
   * `make serve`: starts a local webserver to allow for browsing of documentation
+  * `make test`: runs the validation test suite
+  * `make lint`: runs ruff and linkml-lint
+
+> **Note:** the previous `bdchm[docs]` install extra has been removed.
+> Documentation tooling now lives in the dev dependency group and is
+> installed by `uv sync`.
 
 </details>
 

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,15 +29,18 @@ dev = [
 [tool.ruff]
 line-length = 120
 target-version = "py310"
-# Scoped to first-party test/tooling code. The pre-existing resources/
-# tree and generated artifacts are intentionally out of scope.
+# Lint first-party code (tests/, src/bdchm/). The pre-existing
+# resources/ tree, generated artifacts, and non-code src subtrees
+# (schema data, docs, templates) are intentionally out of scope.
 extend-exclude = [
     "docs/",
     "project/",
     "generated/",
     "generate-diagrams/",
     "resources/",
-    "src/",
+    "src/data/",
+    "src/docs/",
+    "src/doc-templates/",
 ]
 force-exclude = true
 

--- a/src/bdchm/_version.py
+++ b/src/bdchm/_version.py
@@ -1,4 +1,4 @@
-from importlib.metadata import version, PackageNotFoundError
+from importlib.metadata import PackageNotFoundError, version
 
 try:
     __version__ = version(__name__)

--- a/tests/test_schema.py
+++ b/tests/test_schema.py
@@ -43,10 +43,6 @@ def _example_params():
         yield pytest.param(path, id=path.name, marks=marks)
 
 
-@pytest.mark.xfail(
-    reason="schema metamodel fixes land in PR #190; passes once merged",
-    strict=False,
-)
 def test_schema_validates_against_metamodel():
     result = subprocess.run(
         [sys.executable, "-m", "linkml.validator.cli", str(SCHEMA)],


### PR DESCRIPTION
**DRAFT — not ready for merge; pending self-review.**

Addresses self-review + Copilot feedback on the recently-merged #190–#193 stack. Each change maps to one finding:

- **Metamodel test now gates CI** — removed the `xfail` on `test_schema_validates_against_metamodel` (schema is valid since #190; it was silently swallowing future regressions).
- **Fixed `make update-linkml`** — `uv add --dev linkml@latest` fails (uv treats `@latest` as a path); now `uv lock --upgrade-package linkml && uv sync`.
- **ruff version aligned** — `ruff-pre-commit` `v0.11.13` → `v0.15.13` to match `uv.lock`.
- **CI verifies the lockfile** — `uv sync --locked` in both workflows.
- **ruff scope narrowed** — `src/bdchm/` is now linted (was excluding all of `src/`); fixed `_version.py` import order.
- **Deploy workflow** — dropped redundant `setup-python`, pin Python via `setup-uv`.
- **README** — uv workflow, Python ≥3.10, removed-docs-extra note.

Verified locally: `uv sync --locked`; `make test` → 2 passed, 9 xfailed (metamodel now passes as a real gate); ruff + pre-commit clean.

Out of scope (flagged separately): `linkml-lint` reports 24 pre-existing schema *style* warnings (0 validity errors); `make lint` surfaces them but CI doesn't gate on it.