### PR TITLE
DRAFT: vocabulary trust-hierarchy annotations on concept-binding enums

### DIFF
--- a/src/bdchm/schema/bdchm.yaml
+++ b/src/bdchm/schema/bdchm.yaml
@@ -25,6 +25,7 @@ prefixes:
   MMO: http://purl.obolibrary.org/obo/MMO_
   BAO: http://www.bioassayontology.org/bao#BAO_
   UBERON: http://purl.obolibrary.org/obo/UBERON_
+  th: https://w3id.org/bdc/trust-hierarchy/
 
 default_prefix: bdchm
 default_range: string
@@ -1820,6 +1821,12 @@ enums:
         meaning: OMOP:8552
 
   CellularOrganismSpeciesEnum:
+    instantiates:
+      - th:TrustHierarchyBinding
+    annotations:
+      prefer: "NCBITaxon"
+      via: "reachable_from"
+      validation_source: OLS4
     description: >-
       A constrained set of enumerative values containing the NCBITaxon values for cellular organisms.
     reachable_from:
@@ -1831,6 +1838,12 @@ enums:
         - rdfs:subClassOf
 
   AssayMethodEnum:
+    instantiates:
+      - th:TrustHierarchyBinding
+    annotations:
+      prefer: "MMO"
+      via: "reachable_from"
+      validation_source: OLS4
     description: >-
       A constrained set of enumerative values containing the Measurement Method Ontology (MMO) values for assay methods.
     reachable_from:
@@ -1842,6 +1855,12 @@ enums:
         - rdfs:subClassOf
 
   InstrumentEnum:
+    instantiates:
+      - th:TrustHierarchyBinding
+    annotations:
+      prefer: "BAO"
+      via: "reachable_from"
+      validation_source: OLS4
     description: >-
       A constrained set of enumerative values containing the BioAssay Ontology (BAO) values for instruments.
     reachable_from:
@@ -1864,6 +1883,12 @@ enums:
         meaning: OMOP:434489
 
   VertebrateBreedEnum:
+    instantiates:
+      - th:TrustHierarchyBinding
+    annotations:
+      prefer: "VBO"
+      via: "reachable_from"
+      validation_source: OLS4
     description: >-
       A constrained set of enumerative values containing the VBO values for vertebrate breeds.
     reachable_from:
@@ -2210,6 +2235,12 @@ enums:
         - rdfs:subClassOf
 
   AnatomicSiteEnum:
+    instantiates:
+      - th:TrustHierarchyBinding
+    annotations:
+      prefer: "UBERON"
+      via: "reachable_from"
+      validation_source: OLS4
     description: >-
       A constrained set of enumerative values containing the Uberon values for anatomic sites.
     reachable_from:
@@ -2221,6 +2252,13 @@ enums:
         - rdfs:subClassOf
 
   ConditionConceptEnum:
+    instantiates:
+      - th:TrustHierarchyBinding
+    annotations:
+      prefer: "MONDO, HP"
+      fallback: "OMOP:permitted, SNOMED:permitted"
+      via: "inherits, reachable_from"
+      validation_source: OLS4
     description: >-
       A constrained set of enumerative values containing both the MONDO values for human diseases and the HPO values for phenotypic abnormalities.
     inherits:
@@ -2416,11 +2454,26 @@ enums:
             description: was present in the patient historically.
 
   ProcedureConceptEnum:
+    instantiates:
+      - th:TrustHierarchyBinding
+    annotations:
+      prefer: "OMOP"
+      via: "reachable_from"
+      validation_source: OMOP_WebAPI
+      flag: "No procedure ontology in use; OMOP is the sole source. SNOMED floated - curator call."
     description: Procedure codes from OMOP.
     reachable_from:
       source_ontology: OMOP
 
   DrugExposureConceptEnum:
+    instantiates:
+      - th:TrustHierarchyBinding
+    annotations:
+      prefer: "RXNORM"
+      fallback: "OMOP:observed"
+      via: "reachable_from"
+      validation_source: RxNav
+      flag: "USAGE DIVERGES - schema prefers RxNorm but trans-spec drug_concept is OMOP 102 / RxNorm 6. ATC resolves within RxNorm."
     description: Drug codes from RxNorm.
     see_also:
       - https://bioregistry.io/registry/rxnorm
@@ -2986,6 +3039,13 @@ enums:
         meaning: OMOP:40549429                                                   
 
   DeviceExposureConceptEnum:
+    instantiates:
+      - th:TrustHierarchyBinding
+    annotations:
+      prefer: "SNOMED"
+      fallback: "OMOP:permitted"
+      via: "reachable_from"
+      validation_source: OMOP_WebAPI
     description: Device codes from SNOMED.
     see_also:
       - https://bioregistry.io/registry/snomedct
@@ -3661,6 +3721,12 @@ enums:
         description: A processing activity that aims to preserve a specimen.
         
   UnitOfMeasurementEnum:
+    instantiates:
+      - th:TrustHierarchyBinding
+    annotations:
+      prefer: "UOM"
+      via: "reachable_from"
+      validation_source: OLS4
     description: Standard units of measurement from the [Units of Measurement (UOM) ontology](https://units-of-measurement.org/). Units-of-measurement (UOM) provides URLs for Unified Code for Units of Measure (UCUM) codes, and mappings to a number of units ontologies and systems, in human- and machine-readable linked data formats.
     reachable_from:
       source_ontology: UOM
@@ -3753,6 +3819,14 @@ enums:
         meaning: OMOP:4053608
 
   MeasurementObservationTypeEnum:
+    instantiates:
+      - th:TrustHierarchyBinding
+    annotations:
+      prefer: "OBA"
+      fallback: "OMOP:observed"
+      via: "static_pv"
+      validation_source: OLS4
+      flag: "UNRESOLVED - enum is 62 OBA / 50 OMOP and trans-specs are OMOP-heavy (OMOP 592 / OBA 209). Is OBA the intended primary? Curator call."
     description: Values describing the types of MeasurementObservations.
     permissible_values:
       ALBUMIN_IN_BLOOD: 
@@ -4009,6 +4083,13 @@ enums:
         meaning: OMOP:45885135
 
   CauseOfDeathEnum:
+    instantiates:
+      - th:TrustHierarchyBinding
+    annotations:
+      prefer: "ICD10CM"
+      via: "reachable_from"
+      validation_source: OMOP_WebAPI
+      flag: "Terminology, not an ontology. Prefer MONDO (consistent with condition_concept)? Curator call."
     description: >-
       A constrained set of enumerative values containing the ICD-10 diagnoses.
     reachable_from:

--- a/src/bdchm/schema/trust_hierarchy_profile.yaml
+++ b/src/bdchm/schema/trust_hierarchy_profile.yaml
@@ -1,0 +1,37 @@
+id: https://w3id.org/bdc/trust-hierarchy
+name: trust-hierarchy-profile
+title: Vocabulary Trust Hierarchy — LinkML microschema profile
+description: >-
+  A LinkML microschema profile. `TrustHierarchyBinding` is a METACLASS that governs the
+  trust-hierarchy annotations on a concept-binding enum. A binding enum declares
+  `instantiates: [th:TrustHierarchyBinding]` and carries annotations whose keys are this
+  metaclass's attributes. Semantics: ranked preference with permissive fallback; DESCRIPTIVE
+  (records what the host schema already encoded, plus flags). Values are comma-separated
+  strings (the LinkML metamodel disallows array-valued annotations).
+license: MIT
+prefixes:
+  linkml: https://w3id.org/linkml/
+  th: https://w3id.org/bdc/trust-hierarchy/
+default_prefix: th
+default_range: string
+imports:
+  - linkml:types
+classes:
+  TrustHierarchyBinding:
+    class_uri: th:TrustHierarchyBinding
+    description: >-
+      Metaclass governing the trust-hierarchy annotations on a concept-binding enum; its
+      attributes are the valid annotation keys on the instantiating enum.
+    attributes:
+      prefer:
+        description: Comma-separated, ranked preferred source prefixes; first with an apt term wins.
+      fallback:
+        description: >-
+          Comma-separated permitted-not-forbidden fallbacks, each "PREFIX:status"
+          (status = observed | permitted).
+      via:
+        description: Comma-separated provenance of the policy (reachable_from | inherits | static_pv).
+      validation_source:
+        description: Service/authority used to resolve and validate a CURIE for this binding.
+      flag:
+        description: Observed misalignment / unresolved point for curator follow-up.

--- a/src/bdchm/schema/trust_hierarchy_profile.yaml
+++ b/src/bdchm/schema/trust_hierarchy_profile.yaml
@@ -1,13 +1,15 @@
 id: https://w3id.org/bdc/trust-hierarchy
 name: trust-hierarchy-profile
-title: Vocabulary Trust Hierarchy — LinkML microschema profile
+title: Vocabulary Trust Hierarchy - LinkML microschema profile
 description: >-
   A LinkML microschema profile. `TrustHierarchyBinding` is a METACLASS that governs the
   trust-hierarchy annotations on a concept-binding enum. A binding enum declares
   `instantiates: [th:TrustHierarchyBinding]` and carries annotations whose keys are this
   metaclass's attributes. Semantics: ranked preference with permissive fallback; DESCRIPTIVE
   (records what the host schema already encoded, plus flags). Values are comma-separated
-  strings (the LinkML metamodel disallows array-valued annotations).
+  strings (the LinkML metamodel disallows array-valued annotations). Resolved locally by
+  relative path for now (no w3id registration yet); the id URI is an identifier, not relied
+  upon for HTTP resolution.
 license: MIT
 prefixes:
   linkml: https://w3id.org/linkml/
@@ -27,11 +29,23 @@ classes:
         description: Comma-separated, ranked preferred source prefixes; first with an apt term wins.
       fallback:
         description: >-
-          Comma-separated permitted-not-forbidden fallbacks, each "PREFIX:status"
-          (status = observed | permitted).
+          Comma-separated permitted-not-forbidden fallbacks, each "PREFIX:status" where status
+          is a FallbackStatusEnum value.
       via:
-        description: Comma-separated provenance of the policy (reachable_from | inherits | static_pv).
+        description: Comma-separated provenance of the policy; each token a EncodingEnum value.
       validation_source:
         description: Service/authority used to resolve and validate a CURIE for this binding.
       flag:
         description: Observed misalignment / unresolved point for curator follow-up.
+enums:
+  EncodingEnum:
+    description: How a binding's preference is declared in the host schema.
+    permissible_values:
+      reachable_from:
+      inherits:
+      static_pv:
+  FallbackStatusEnum:
+    description: Whether a fallback is actually observed in data, or merely permitted.
+    permissible_values:
+      observed:
+      permitted:

--- a/tests/test_trust_hierarchy.py
+++ b/tests/test_trust_hierarchy.py
@@ -1,8 +1,10 @@
-"""Validate the trust-hierarchy annotations on bdchm concept-binding enums.
+"""Validate the trust-hierarchy annotations on bdchm concept-binding enums against the
+trust-hierarchy microschema profile, resolved locally by relative path.
 
-This is the self-consistency check co-located as CI: every enum that declares
-`instantiates: th:TrustHierarchyBinding` must carry a well-formed trust_hierarchy
-annotation (governed by the trust-hierarchy microschema profile).
+The profile (trust_hierarchy_profile.yaml) is the source of truth: allowed annotation keys,
+via-tokens, and fallback statuses are derived from it, so the schema and its governing
+metaclass cannot drift. The profile is referenced by `instantiates` (a CURIE) in bdchm but
+not imported (which would emit the metaclass into the generated datamodel).
 """
 
 from pathlib import Path
@@ -10,29 +12,44 @@ from pathlib import Path
 import pytest
 from linkml_runtime import SchemaView
 
-SCHEMA = Path(__file__).resolve().parent.parent / "src" / "bdchm" / "schema" / "bdchm.yaml"
+SCHEMA_DIR = Path(__file__).resolve().parent.parent / "src" / "bdchm" / "schema"
+BDCHM = SCHEMA_DIR / "bdchm.yaml"
+PROFILE = SCHEMA_DIR / "trust_hierarchy_profile.yaml"
 META = "th:TrustHierarchyBinding"
-ALLOWED = {"prefer", "fallback", "via", "validation_source", "flag"}
-VIA = {"reachable_from", "inherits", "static_pv"}
-STATUS = {"observed", "permitted"}
+
+
+@pytest.fixture(scope="module")
+def profile():
+    sv = SchemaView(str(PROFILE))
+    cls = sv.get_class("TrustHierarchyBinding")
+    assert cls is not None, "profile must define the TrustHierarchyBinding metaclass"
+    return {
+        "keys": set(cls.attributes.keys()),
+        "via": set(sv.get_enum("EncodingEnum").permissible_values.keys()),
+        "status": set(sv.get_enum("FallbackStatusEnum").permissible_values.keys()),
+    }
 
 
 @pytest.fixture(scope="module")
 def th_enums():
-    sv = SchemaView(str(SCHEMA))
+    sv = SchemaView(str(BDCHM))
     return {n: e for n, e in sv.all_enums().items() if e.instantiates and META in e.instantiates}
+
+
+def test_profile_defines_expected_attributes(profile):
+    assert {"prefer", "fallback", "via", "validation_source", "flag"} <= profile["keys"]
 
 
 def test_bindings_present(th_enums):
     assert len(th_enums) >= 12
 
 
-def test_annotation_shape(th_enums):
+def test_annotations_conform_to_profile(th_enums, profile):
     for name, e in th_enums.items():
         ann = {k: v.value for k, v in e.annotations.items()}
-        assert set(ann) <= ALLOWED, f"{name}: unexpected keys {set(ann) - ALLOWED}"
+        assert set(ann) <= profile["keys"], f"{name}: keys not in profile: {set(ann) - profile['keys']}"
         assert ann.get("prefer", "").strip() or "flag" in ann, f"{name}: empty prefer and no flag"
         for v in [x.strip() for x in ann.get("via", "").split(",") if x.strip()]:
-            assert v in VIA, f"{name}: bad via token '{v}'"
+            assert v in profile["via"], f"{name}: via token '{v}' not in profile EncodingEnum"
         for fb in [x.strip() for x in ann.get("fallback", "").split(",") if x.strip()]:
-            assert ":" in fb and fb.split(":")[1] in STATUS, f"{name}: bad fallback '{fb}'"
+            assert ":" in fb and fb.split(":")[1] in profile["status"], f"{name}: bad fallback '{fb}'"

--- a/tests/test_trust_hierarchy.py
+++ b/tests/test_trust_hierarchy.py
@@ -4,7 +4,9 @@ This is the self-consistency check co-located as CI: every enum that declares
 `instantiates: th:TrustHierarchyBinding` must carry a well-formed trust_hierarchy
 annotation (governed by the trust-hierarchy microschema profile).
 """
+
 from pathlib import Path
+
 import pytest
 from linkml_runtime import SchemaView
 
@@ -29,7 +31,7 @@ def test_annotation_shape(th_enums):
     for name, e in th_enums.items():
         ann = {k: v.value for k, v in e.annotations.items()}
         assert set(ann) <= ALLOWED, f"{name}: unexpected keys {set(ann) - ALLOWED}"
-        assert (ann.get("prefer", "").strip() or "flag" in ann), f"{name}: empty prefer and no flag"
+        assert ann.get("prefer", "").strip() or "flag" in ann, f"{name}: empty prefer and no flag"
         for v in [x.strip() for x in ann.get("via", "").split(",") if x.strip()]:
             assert v in VIA, f"{name}: bad via token '{v}'"
         for fb in [x.strip() for x in ann.get("fallback", "").split(",") if x.strip()]:

--- a/tests/test_trust_hierarchy.py
+++ b/tests/test_trust_hierarchy.py
@@ -1,0 +1,36 @@
+"""Validate the trust-hierarchy annotations on bdchm concept-binding enums.
+
+This is the self-consistency check co-located as CI: every enum that declares
+`instantiates: th:TrustHierarchyBinding` must carry a well-formed trust_hierarchy
+annotation (governed by the trust-hierarchy microschema profile).
+"""
+from pathlib import Path
+import pytest
+from linkml_runtime import SchemaView
+
+SCHEMA = Path(__file__).resolve().parent.parent / "src" / "bdchm" / "schema" / "bdchm.yaml"
+META = "th:TrustHierarchyBinding"
+ALLOWED = {"prefer", "fallback", "via", "validation_source", "flag"}
+VIA = {"reachable_from", "inherits", "static_pv"}
+STATUS = {"observed", "permitted"}
+
+
+@pytest.fixture(scope="module")
+def th_enums():
+    sv = SchemaView(str(SCHEMA))
+    return {n: e for n, e in sv.all_enums().items() if e.instantiates and META in e.instantiates}
+
+
+def test_bindings_present(th_enums):
+    assert len(th_enums) >= 12
+
+
+def test_annotation_shape(th_enums):
+    for name, e in th_enums.items():
+        ann = {k: v.value for k, v in e.annotations.items()}
+        assert set(ann) <= ALLOWED, f"{name}: unexpected keys {set(ann) - ALLOWED}"
+        assert (ann.get("prefer", "").strip() or "flag" in ann), f"{name}: empty prefer and no flag"
+        for v in [x.strip() for x in ann.get("via", "").split(",") if x.strip()]:
+            assert v in VIA, f"{name}: bad via token '{v}'"
+        for fb in [x.strip() for x in ann.get("fallback", "").split(",") if x.strip()]:
+            assert ":" in fb and fb.split(":")[1] in STATUS, f"{name}: bad fallback '{fb}'"


### PR DESCRIPTION
**DRAFT — not ready for review.** Parking this to keep iterating; the values still need ground-truthing and curation reconciliation before anyone should look closely.

## What this adds
A computable, **descriptive** vocabulary *trust hierarchy* on bdchm's concept-binding enums: per binding, the preferred ontology/vocabulary (ranked) with **permitted fallbacks**, as native LinkML annotations.

- `src/bdchm/schema/trust_hierarchy_profile.yaml` — small microschema profile defining `TrustHierarchyBinding`, the metaclass governing the annotation keys.
- 12 Tier-1 concept-binding enums in `bdchm.yaml` now declare `instantiates: [th:TrustHierarchyBinding]` and carry a `trust_hierarchy` annotation: `prefer`, `fallback` (`PREFIX:status`), `via`, `validation_source`, `flag`.
- `th:` prefix added.
- `tests/test_trust_hierarchy.py` — validates annotation shape (self-consistency check, co-located as CI).

## Semantics
Ranked preference **with permissive fallback** — not a single-vocab validation gate. A fallback is valid-but-flagged, never an error. The annotation is **descriptive**: it records the decision each enum already encodes (from `reachable_from`/`inherits`/`permissible_values`) and flags misalignments for curators.

## Notable flags (surfaced for curators; not decided here)
- `MeasurementObservationTypeEnum`: enum is 62 OBA / 50 OMOP and trans-specs are OMOP-heavy — preferred source unresolved.
- `DrugExposureConceptEnum`: schema prefers RxNorm but trans-specs are OMOP-heavy.
- `ProcedureConceptEnum`: OMOP-only, no procedure ontology.

## Encoding notes
- Annotation values are comma-separated **strings** (the LinkML metamodel disallows array-valued annotations; lint `valid-schema` rejects lists).
- `instantiates` declares the governing metaclass; native enforcement (instantiates validation plugin, linkml >= 1.11) can validate the shape later — the test covers it now. No linkml upgrade required.

## Still pending (why it's draft)
- [ ] Ground-truth `prefer`/`fallback`/`flag` rigorously against the trans-specs.
- [ ] Reconcile with curation tooling (`_SLOT_VOCAB_RULES` / wiki).
- [ ] Curator-owned rankings on the flagged bindings.
- [ ] Tier-2 categorical value-enums (sex/race/etc.) not yet covered.
