### PR TITLE
DRAFT: trust hierarchy as data (microschema + bdchm policy) — alt to #207

### DIFF
--- a/tests/test_trust_hierarchy.py
+++ b/tests/test_trust_hierarchy.py
@@ -1,0 +1,36 @@
+"""CI checks for the trust-hierarchy artifact.
+
+Two checks, both standard (no bespoke consumer code):
+  1. The data conforms to the trust-hierarchy microschema (linkml validation).
+  2. Every binding's `class_name.slot_name` is a real (class, slot) in bdchm
+     -- i.e. the modeling constraint actually points at something in the model.
+"""
+
+from pathlib import Path
+
+import yaml
+from linkml.validator import validate
+from linkml_runtime import SchemaView
+
+ROOT = Path(__file__).resolve().parent.parent
+TH_DIR = ROOT / "trust_hierarchy"
+SCHEMA = TH_DIR / "trust_hierarchy.schema.yaml"
+DATA = TH_DIR / "bdchm_trust_hierarchy.yaml"
+BDCHM = ROOT / "src" / "bdchm" / "schema" / "bdchm.yaml"
+
+
+def test_data_conforms_to_microschema():
+    report = validate(yaml.safe_load(DATA.read_text()), str(SCHEMA), "TrustHierarchy")
+    assert not report.results, [r.message for r in report.results]
+
+
+def test_bindings_reference_real_bdchm_slots():
+    sv = SchemaView(str(BDCHM))
+    classes = sv.all_classes()
+    bindings = yaml.safe_load(DATA.read_text())["bindings"]
+    assert len(bindings) >= 12
+    for b in bindings:
+        cls, slot = b["class_name"], b["slot_name"]
+        assert cls in classes, f"{b['id']}: class '{cls}' not in bdchm"
+        slot_names = {s.name for s in sv.class_induced_slots(cls)}
+        assert slot in slot_names, f"{b['id']}: slot '{slot}' not on class '{cls}'"

--- a/trust_hierarchy/bdchm_trust_hierarchy.yaml
+++ b/trust_hierarchy/bdchm_trust_hierarchy.yaml
@@ -1,0 +1,90 @@
+# BDC vocabulary trust hierarchy (DATA) — conforms to trust_hierarchy.schema.yaml.
+# Ranked preference + permissive fallback per bdchm (class, slot). DESCRIPTIVE: prefer
+# records the decision bdchm already encodes; flags surface misalignments for curators.
+target_schema: "bdchm @ f3fc769"
+
+bindings:
+  - id: Condition.condition_concept
+    class_name: Condition
+    slot_name: condition_concept
+    prefer: [MONDO, HP]
+    fallback:
+      - {prefix: OMOP, status: permitted}
+      - {prefix: SNOMED, status: permitted}
+    validation_source: OLS4
+
+  - id: MeasurementObservation.observation_type
+    class_name: MeasurementObservation
+    slot_name: observation_type
+    prefer: [OBA]
+    fallback:
+      - {prefix: OMOP, status: observed}
+    validation_source: OLS4
+    flag: "OBA/OMOP split in the enum and trans-spec usage leans OMOP; preferred source unresolved (curator call)."
+
+  - id: DrugExposure.drug_concept
+    class_name: DrugExposure
+    slot_name: drug_concept
+    prefer: [RXNORM]
+    fallback:
+      - {prefix: OMOP, status: observed}
+    validation_source: RxNav
+    flag: "Schema prefers RxNorm but trans-spec usage leans OMOP. ATC resolves within RxNorm."
+
+  - id: Procedure.procedure_concept
+    class_name: Procedure
+    slot_name: procedure_concept
+    prefer: [OMOP]
+    validation_source: OMOP_WebAPI
+    flag: "No procedure ontology in use; OMOP is the sole source. SNOMED floated (curator call)."
+
+  - id: DeviceExposure.device_concept
+    class_name: DeviceExposure
+    slot_name: device_concept
+    prefer: [SNOMED]
+    fallback:
+      - {prefix: OMOP, status: permitted}
+    validation_source: OMOP_WebAPI
+
+  - id: CauseOfDeath.cause
+    class_name: CauseOfDeath
+    slot_name: cause
+    prefer: [ICD10CM]
+    validation_source: OMOP_WebAPI
+    flag: "Terminology, not an ontology. Prefer MONDO (consistent with condition_concept)? Curator call."
+
+  - id: BodySite.site
+    class_name: BodySite
+    slot_name: site
+    prefer: [UBERON]
+    validation_source: OLS4
+
+  - id: Assay.method
+    class_name: Assay
+    slot_name: method
+    prefer: [MMO]
+    validation_source: OLS4
+
+  - id: Assay.instrument
+    class_name: Assay
+    slot_name: instrument
+    prefer: [BAO]
+    validation_source: OLS4
+
+  - id: Person.species
+    class_name: Person
+    slot_name: species
+    prefer: [NCBITaxon]
+    validation_source: OLS4
+
+  - id: Person.breed
+    class_name: Person
+    slot_name: breed
+    prefer: [VBO]
+    validation_source: OLS4
+
+  - id: Quantity.unit
+    class_name: Quantity
+    slot_name: unit
+    prefer: [UOM]
+    validation_source: OLS4

--- a/trust_hierarchy/bdchm_trust_hierarchy.yaml
+++ b/trust_hierarchy/bdchm_trust_hierarchy.yaml
@@ -64,12 +64,14 @@ bindings:
     slot_name: method
     prefer: [MMO]
     validation_source: OLS4
+    flag: "We hold MMO (a purpose-built measurement-method ontology, per bdchm's encoding); Stephanie's wiki prefers LOINC. Reconcile."
 
   - id: Assay.instrument
     class_name: Assay
     slot_name: instrument
     prefer: [BAO]
     validation_source: OLS4
+    flag: "We hold BAO (BioAssay Ontology, per bdchm's encoding); Stephanie's wiki prefers LOINC. Reconcile."
 
   - id: Person.species
     class_name: Person
@@ -87,4 +89,11 @@ bindings:
     class_name: Quantity
     slot_name: unit
     prefer: [UOM]
+    validation_source: OLS4
+
+  # From Stephanie (on merit): DUO is ontology-backed; closes a real gap.
+  - id: Consent.consent_code
+    class_name: Consent
+    slot_name: consent_code
+    prefer: [DUO]
     validation_source: OLS4

--- a/trust_hierarchy/bdchm_trust_hierarchy.yaml
+++ b/trust_hierarchy/bdchm_trust_hierarchy.yaml
@@ -97,3 +97,22 @@ bindings:
     slot_name: consent_code
     prefer: [DUO]
     validation_source: OLS4
+
+  # Race/ethnicity: adopt Stephanie's call (OMB = US federal standard); bdchm currently encodes OMOP.
+  - id: Demography.race
+    class_name: Demography
+    slot_name: race
+    prefer: [OMB]
+    fallback:
+      - {prefix: OMOP, status: observed}
+    validation_source: OMB
+    flag: "bdchm encodes OMOP; OMB (US federal standard) preferred per Stephanie -- model may need to move to OMB."
+
+  - id: Demography.ethnicity
+    class_name: Demography
+    slot_name: ethnicity
+    prefer: [OMB]
+    fallback:
+      - {prefix: OMOP, status: observed}
+    validation_source: OMB
+    flag: "bdchm encodes OMOP; OMB (US federal standard) preferred per Stephanie -- model may need to move to OMB."

--- a/trust_hierarchy/trust_hierarchy.schema.yaml
+++ b/trust_hierarchy/trust_hierarchy.schema.yaml
@@ -1,0 +1,71 @@
+id: https://w3id.org/bdc/trust-hierarchy
+name: trust-hierarchy
+title: Vocabulary Trust Hierarchy
+description: >-
+  Declares, per (class, slot) binding in a target LinkML model, a ranked vocabulary
+  preference with permissive fallback for the CURIEs that fill that slot. The unit of use
+  is the class.slot ("in this class.slot we maintain this trust hierarchy"). The slot's range
+  enums and their sources are read from the target model itself and are not re-encoded here;
+  this artifact adds only the prescriptive policy the model lacks.
+license: MIT
+prefixes:
+  linkml: https://w3id.org/linkml/
+  th: https://w3id.org/bdc/trust-hierarchy/
+default_prefix: th
+default_range: string
+imports:
+  - linkml:types
+
+classes:
+  TrustHierarchy:
+    tree_root: true
+    description: A set of slot bindings — the policy for a target model.
+    attributes:
+      target_schema:
+        description: The LinkML model these bindings govern (e.g. "bdchm @ <commit/version>").
+      bindings:
+        description: One policy per governed (class, slot).
+        range: SlotBinding
+        multivalued: true
+        inlined_as_list: true
+
+  SlotBinding:
+    description: >-
+      "In this class.slot we maintain this trust hierarchy." The unit of use.
+    attributes:
+      id:
+        identifier: true
+        description: ClassName.slot_name, e.g. Condition.condition_concept.
+      class_name:
+        required: true
+      slot_name:
+        required: true
+      prefer:
+        description: Ranked preferred source prefixes; first with an apt, specific term wins.
+        multivalued: true
+      fallback:
+        description: Permitted-not-forbidden fallback sources.
+        range: Fallback
+        multivalued: true
+        inlined_as_list: true
+      validation_source:
+        description: Service/authority used to resolve and validate a CURIE for this slot.
+      rationale:
+      flag:
+        description: Observed misalignment / unresolved point for curator follow-up.
+
+  Fallback:
+    description: A permitted fallback source and whether it is actually observed in data.
+    attributes:
+      prefix:
+        key: true
+      status:
+        range: FallbackStatusEnum
+      note:
+
+enums:
+  FallbackStatusEnum:
+    description: Whether a fallback actually appears in data, or is merely permitted.
+    permissible_values:
+      observed:
+      permitted:


### PR DESCRIPTION
**DRAFT — for review, not merge.** The vocabulary trust hierarchy as *data* (microschema + policy instance), the alternative to the annotations approach in #207.

## What this is
The trust hierarchy as **data conforming to a small microschema**, not annotations on bdchm's enums. Unit of use = the `(class, slot)` binding.

- `trust_hierarchy/trust_hierarchy.schema.yaml` — the microschema (`SlotBinding` keyed by `Class.slot`; `prefer` ranked list + `fallback` objects + `validation_source` + `flag`). Portable — nothing BDC-specific — so it can graduate to its own repo later.
- `trust_hierarchy/bdchm_trust_hierarchy.yaml` — the BDC policy: **15 bindings** as data instances.
- `tests/test_trust_hierarchy.py` — data conforms to the microschema, and every binding points at a real bdchm `(class, slot)`.

## Semantics
Ranked preference **with permissive fallback** — a fallback is valid-but-flagged, never an error. Descriptive: records what bdchm already encodes, and flags misalignments for curators.

## Why data, not annotations (vs #207)
As data we recover native ranked lists and structured fallbacks (the array-valued-annotation limit only bites *annotations*); it's not redundant with `reachable_from`/`inherits`; it doesn't pollute the generated datamodel; and it's curator-editable. The one thing #207 had — reachability via a single bdchm import — isn't achievable for instance data and is exactly what made #207 compromised.

## First cut — reconciled against Stephanie's wiki (10/12 core vocabs already agree)
- **Taken from her (on merit):** `Consent.consent_code → DUO` (ontology-backed) and `race`/`ethnicity → OMB` (US federal standard; OMOP kept as observed fallback since bdchm encodes it).
- **Held our ground:** `Assay.method = MMO` / `Assay.instrument = BAO` over her LOINC — purpose-built ontologies, matching bdchm's encoding; flagged to reconcile.
- **Still parked (open):** the measurement value/result layer (LOINC/OMOP), distinct from `observation_type = OBA`.

## How this compares to Stephanie's two existing pieces

Stephanie's policy lives in two places that already diverge: a **code** gate (`_SLOT_VOCAB_RULES`, 2 slots, actually runs) and a **wiki** table (~14 domains, human guidance, unenforced).

| Dimension | Code (`_SLOT_VOCAB_RULES`) | Wiki table | This PR |
|---|---|---|---|
| Form | Python dict in a curation script | Prose/table on the wiki | LinkML microschema + validated data |
| Unit | bare slot name | loose "domain" | `(class, slot)` |
| Coverage | 2 slots | ~14 domains | 15 bindings |
| Semantics | gate — reject/suppress | guidance — unenforced | ranked prefer + permissive fallback |
| Ranking / fallback | none | none | ordered list + typed fallback |
| Machine-consumable | executable, app-coupled | no (human only) | yes — any tool can read it |
| Enforces today? | ✅ yes (gates curation) | no | not yet (no consumer wired) |
| Checked vs bdchm | prose notes | none | ✅ CI: every binding is a real slot |
| Editor | dev (Python) | curator (free text) | curator (validated YAML) |

**Takeaways:**
- Stephanie's two pieces split by scope *and* role: the code is **narrow but operational**; the wiki is **broad but aspirational**, and they drift.
- This artifact **collapses those roles into one** validated source that could both feed an executable gate (replace `_SLOT_VOCAB_RULES`) and be the human/curator policy (replace the wiki table).
- Honest tradeoff: hers is *operational-but-fragmented*; this is *unified-and-computable-but-not-yet-operational* — it earns its value once a consumer (her generator, or the KG) reads it.
- Semantics differ: her code *rejects*; this *permits-and-flags*. Mapping for a consumer: `prefer`→valid, `fallback`→warn, off-policy→suppress.
- One live vocab conflict — Assay method/instrument (wiki LOINC vs this MMO/BAO) — is **not** enforced by her code, so it's a wiki-vs-model judgment call to settle with her.

## Homes
Both live in the bdchm repo for now (the hierarchy as a modeling constraint co-located with the model); the microschema is written to extract to a standalone/reusable repo later.
