### PR TITLE
Update associated_assay to associated_artifact

### DIFF
--- a/generated/bdchm.schema.json
+++ b/generated/bdchm.schema.json
@@ -1691,8 +1691,8 @@
                         "null"
                     ]
                 },
-                "associated_assay": {
-                    "description": "A reference to the assay that was used in generating this observation.",
+                "associated_artifact": {
+                    "description": "A reference to the assay, file, or questionnaire response that was used in generating this observation.",
                     "type": [
                         "string",
                         "null"

--- a/generated/bdchm.schema.ts
+++ b/generated/bdchm.schema.ts
@@ -2679,8 +2679,8 @@ export interface MeasurementObservation extends Observation {
     range_high?: QuantityId,
     /** The type of Observation being represented (e.g. 'diastolic blood pressure') */
     observation_type: string,
-    /** A reference to the assay that was used in generating this observation. */
-    associated_assay?: AssayId,
+    /** A reference to the assay, file, or questionnaire response that was used in generating this observation. */
+    associated_artifact?: AssayId,
     /** The body site that is the focus of this observation, if applicable. */
     body_site?: BodySiteId,
     /** The position of the body that is the focus of this observation, if applicable. */

--- a/src/bdchm/schema/bdchm.yaml
+++ b/src/bdchm/schema/bdchm.yaml
@@ -1606,9 +1606,13 @@ classes:
           - This field holds the "key" in the core key-value pair comprised of the observation_type field and the relevant value(s) field.
         range: MeasurementObservationTypeEnum
         required: true
-      associated_assay:
-        description: A reference to the assay that was used in generating this observation.
-        range: Assay
+      associated_artifact:
+        description: A reference to the assay, file, or questionnaire that was used in generating this observation.
+        range: Any
+        any_of:
+          - range: Assay
+          - range: File
+          - range: QuestionnaireResponse
         required: false
       body_site:
         description: The body site that is the focus of this observation, if applicable.

--- a/src/bdchm/schema/bdchm.yaml
+++ b/src/bdchm/schema/bdchm.yaml
@@ -1608,7 +1608,7 @@ classes:
         required: true
       associated_artifact:
         description: A reference to the assay, file, or questionnaire that was used in generating this observation.
-        range: Any
+        range: Entity
         any_of:
           - range: Assay
           - range: File


### PR DESCRIPTION
Replaced 'associated_assay' with 'associated_artifact' to include multiple types of references.

Updated associated assay as discussed in the last task 3 meeting. See what you think.