### PR TITLE
Refactor MeasurementObservationTypeEnum to use CURIE permissible values

### DIFF
--- a/src/bdchm/schema/bdchm.yaml
+++ b/src/bdchm/schema/bdchm.yaml
@@ -3791,73 +3791,73 @@ enums:
     permissible_values:
 
       "OBA:2050068":
-        description: "Albumin in blood | The amount of a albumin when measured in blood serum."
+        description: "Albumin in blood | The amount of albumin when measured in blood serum."
         meaning: OBA:2050068
       "OBA:2050075":
-        description: "Alpha-1 antitrypsin in serum | The amount of a alpha-1-antitrypsin when measured in blood serum."
+        description: "Alpha-1 antitrypsin in serum | The amount of alpha-1-antitrypsin when measured in blood serum."
         meaning: OBA:2050075
       "OBA:2050062":
-        description: "ALT SGPT | The amount of a alanine aminotransferase when measured in blood serum."
+        description: "ALT SGPT | The amount of alanine aminotransferase when measured in blood serum."
         meaning: OBA:2050062
       "OBA:VT0002607":
         description: "basophils count | The amount of a basophil."
         meaning: OBA:VT0002607
       "OBA:VT0001569":
-        description: "Bilirubin Unconjugated Indirect | The amount of a bilirubin IXalpha when measured in blood."
+        description: "Bilirubin Unconjugated Indirect | The amount of bilirubin IXalpha when measured in blood."
         meaning: OBA:VT0001569
       "OBA:2045455":
         description: "BMI | A compound attribute that is the ratio of body mass to body height."
         meaning: OBA:2045455
       "OBA:2045303":
-        description: "BNP | The amount of a natriuretic peptides B when measured in anatomical entity."
+        description: "BNP | The amount of natriuretic peptides B when measured in anatomical entity."
         meaning: OBA:2045303
       "OBA:VT0001259":
         description: "Body weight | The mass of a multicellular organism."
         meaning: OBA:VT0001259
       "OBA:VT0005265":
-        description: "BUN | The amount of a urea when measured in blood."
+        description: "BUN | The amount of urea when measured in blood."
         meaning: OBA:VT0005265
       "OBA:2052305":
-        description: "CD40 in blood | The amount of a CD40 ligand (human) when measured in blood."
+        description: "CD40 in blood | The amount of CD40 ligand (human) when measured in blood."
         meaning: OBA:2052305
       "OBA:VT0003018":
-        description: "Chloride in blood | The amount of a chloride when measured in blood."
+        description: "Chloride in blood | The amount of chloride when measured in blood."
         meaning: OBA:VT0003018
       "OBA:2050096":
-        description: "Creatinine in blood | The amount of a creatinine when measured in blood serum."
+        description: "Creatinine in blood | The amount of creatinine when measured in blood serum."
         meaning: OBA:2050096
       "OBA:VT0010540":
-        description: "Creatinine in urine | The amount of a creatinine when measured in urine."
+        description: "Creatinine in urine | The amount of creatinine when measured in urine."
         meaning: OBA:VT0010540
       "OBA:2052375":
-        description: "Cystatin C in blood | The amount of a cystatin-C (human) when measured in blood."
+        description: "Cystatin C in blood | The amount of cystatin-C (human) when measured in blood."
         meaning: OBA:2052375
       "OBA:2052778":
-        description: "E-selectin in blood | The amount of a E-selectin (human) when measured in blood."
+        description: "E-selectin in blood | The amount of E-selectin (human) when measured in blood."
         meaning: OBA:2052778
       "OBA:VT0002602":
         description: "Eosinophils count | The amount of a eosinophil."
         meaning: OBA:VT0002602
       "OBA:2045235":
-        description: "Erythrocyte Sed Rate | The buoyancy of a erythrocyte."
+        description: "Erythrocyte Sed Rate | The buoyancy of an erythrocyte."
         meaning: OBA:2045235
       "OBA:2041535":
-        description: "Factor VII | The amount of a coagulation factor VII when measured in blood serum."
+        description: "Factor VII | The amount of coagulation factor VII when measured in blood serum."
         meaning: OBA:2041535
       "OBA:VT0010513":
-        description: "Ferritin | The amount of a ferritin complex when measured in blood."
+        description: "Ferritin | The amount of ferritin complex when measured in blood."
         meaning: OBA:VT0010513
       "OBA:0000061":
-        description: "Fibrinogen | The amount of a fibrinogen complex."
+        description: "Fibrinogen | The amount of fibrinogen complex."
         meaning: OBA:0000061
       "OBA:0003747":
-        description: "GFR | The rate of a glomerular filtration."
+        description: "GFR | The rate of glomerular filtration."
         meaning: OBA:0003747
       "OBA:VT0000188":
-        description: "Glucose in blood | The amount of a glucose when measured in blood."
+        description: "Glucose in blood | The amount of glucose when measured in blood."
         meaning: OBA:VT0000188
       "OBA:VT0000184":
-        description: "HDL | The amount of a high-density lipoprotein cholesterol when measured in blood."
+        description: "HDL | The amount of high-density lipoprotein cholesterol when measured in blood."
         meaning: OBA:VT0000184
       "OBA:1001087":
         description: "Heart rate | The rate of a heart contraction."
@@ -3866,43 +3866,43 @@ enums:
         description: "Height | The height of a multicellular organism."
         meaning: OBA:VT0001253
       "OBA:2045381":
-        description: "Hematocrit | The volume of a erythrocyte when measured in blood."
+        description: "Hematocrit | The volume of an erythrocyte when measured in blood."
         meaning: OBA:2045381
       "OBA:2060175":
-        description: "Hemoglobin | The amount of a hemoglobin when measured in blood."
+        description: "Hemoglobin | The amount of hemoglobin when measured in blood."
         meaning: OBA:2060175
       "OBA:1000032":
         description: "Hip circumference | The circumference of a hip."
         meaning: OBA:1000032
       "OBA:2060174":
-        description: "Insulin in blood | The amount of a insulin when measured in blood."
+        description: "Insulin in blood | The amount of insulin when measured in blood."
         meaning: OBA:2060174
       "OBA:2052890":
-        description: "interleukin 6 in blood | The amount of a interleukin-6 (human) when measured in blood."
+        description: "IL6 | interleukin 6 in blood | The amount of interleukin-6 (human) when measured in blood."
         meaning: OBA:2052890
       "OBA:VT0010477":
-        description: "Lactate Dehydrogenase LDH | The amount of a lactate dehydrogenase complex when measured in blood."
+        description: "Lactate Dehydrogenase LDH | The amount of lactate dehydrogenase complex when measured in blood."
         meaning: OBA:VT0010477
       "OBA:VT0010616":
-        description: "Lactate in blood | The amount of a lactate when measured in blood."
+        description: "Lactate in blood | The amount of lactate when measured in blood."
         meaning: OBA:VT0010616
       "OBA:VT0000181":
-        description: "LDL | The amount of a low-density lipoprotein cholesterol when measured in blood."
+        description: "LDL | The amount of low-density lipoprotein cholesterol when measured in blood."
         meaning: OBA:VT0000181
       "OBA:VT0000717":
-        description: "Lymphocytes count | The has number of of a lymphocyte."
+        description: "Lymphocytes count | The number of lymphocytes."
         meaning: OBA:VT0000717
       "OBA:2052436":
-        description: "MCP1 in blood | The amount of a C-C motif chemokine 2 (human) when measured in blood."
+        description: "MCP1 in blood | The amount of C-C motif chemokine 2 (CCL2)(human) when measured in blood."
         meaning: OBA:2052436
       "OBA:VT2000000":
-        description: "Mean arterial pressure | The pressure of a arterial blood."
+        description: "Mean arterial pressure | The pressure of arterial blood."
         meaning: OBA:VT2000000
       "OBA:2045301":
-        description: "mean corpuscular hemoglobin | The amount of a hemoglobin when measured in erythrocyte."
+        description: "mean corpuscular hemoglobin | The amount of hemoglobin when measured in an erythrocyte."
         meaning: OBA:2045301
       "OBA:0003460":
-        description: "mean corpuscular volume | The volume of a erythrocyte."
+        description: "mean corpuscular volume | The volume of an erythrocyte."
         meaning: OBA:0003460
       "OBA:0003277":
         description: "mean platelet volume | The volume of a platelet."
@@ -3920,79 +3920,79 @@ enums:
         description: "P-selectin in blood | The amount of a P-selectin (human) when measured in blood."
         meaning: OBA:2052701
       "OBA:2045409":
-        description: "pH of blood | The acidity of a blood."
+        description: "pH of blood | The acidity of blood."
         meaning: OBA:2045409
       "OBA:VT0002668":
-        description: "Potassium in blood | The amount of a potassium atom when measured in blood."
+        description: "Potassium in blood | The amount of potassium when measured in blood."
         meaning: OBA:VT0002668
       "OBA:1001086":
         description: "QRS interval | See also EFO_0005054"
         meaning: OBA:1001086
       "OBA:VT0001586":
-        description: "Red blood cell count | The amount of a erythrocyte."
+        description: "Red blood cell count | The amount of erythrocytes. | RBC"
         meaning: OBA:VT0001586
       "OBA:2040171":
-        description: "Sleep hours | The duration of a sleep."
+        description: "Sleep hours | The duration of sleep."
         meaning: OBA:2040171
       "OBA:VT0001776":
-        description: "Sodium in blood | The amount of a sodium atom when measured in blood."
+        description: "Sodium in blood | The amount of sodium when measured in blood."
         meaning: OBA:VT0001776
       "OBA:2045443":
-        description: "SpO2 | The concentration of of a oxygen atom when measured in blood."
+        description: "SpO2 | The concentration of oxygen when measured in blood."
         meaning: OBA:2045443
       "OBA:VT0005535":
         description: "Temperature | The temperature of a multicellular organism."
         meaning: OBA:VT0005535
       "OBA:2051979":
-        description: "TNFa in blood | The amount of a tumor necrosis factor (human) when measured in blood."
+        description: "TNFa in blood | The amount of tumor necrosis factor (human) when measured in blood."
         meaning: OBA:2051979
       "OBA:2051975":
-        description: "TNFa-R1 in blood | The amount of a tumor necrosis factor receptor superfamily member 1A (human) when measured in blood."
+        description: "TNFa-R1 in blood | The amount of tumor necrosis factor receptor superfamily member 1A (human) when measured in blood."
         meaning: OBA:2051975
       "OBA:VT0000180":
-        description: "Total cholesterol in blood | The amount of a cholesterol when measured in blood."
+        description: "Total cholesterol in blood | The amount of cholesterol when measured in blood."
         meaning: OBA:VT0000180
       "OBA:VT0002644":
-        description: "Triglycerides in blood | The amount of a triglyceride when measured in blood."
+        description: "Triglycerides in blood | The amount of triglycerides when measured in blood."
         meaning: OBA:VT0002644
       "OBA:2052741":
-        description: "von Willebrand factor | The amount of a von Willebrand factor (human) when measured in blood."
+        description: "von Willebrand factor | The amount of von Willebrand factor (human) when measured in blood."
         meaning: OBA:2052741
       "OBA:1001085":
-        description: "Waist circumference | The circumference of a abdominal segment of trunk."
+        description: "Waist circumference | The circumference of an abdominal segment of trunk."
         meaning: OBA:1001085
       "OBA:VT0000217":
-        description: "White blood cell count | The amount of a leukocyte."
+        description: "White blood cell count | The amount of leukocytes."
         meaning: OBA:VT0000217
       "OBA:VT0002871":
-        description: "Albumin in urine | The amount of a albumin type when measured in urine."
+        description: "Albumin in urine | The amount of albumin when measured in urine."
         meaning: OBA:VT0002871
       "OBA:2041536":
-        description: "Factor VIII | The amount of a coagulation factor VIII when measured in blood serum."
+        description: "Factor VIII | The amount of coagulation factor VIII when measured in blood serum."
         meaning: OBA:2041536
       "OBA:VT0000223":
-        description: "monocytes count | The amount of a monocyte."
+        description: "monocytes count | The amount of monocytes."
         meaning: OBA:VT0000223
       "OMOP:4282779":
-        description: "SNOMED Smoking status | Cigarette smoking tobacco"
+        description: "SNOMED | Cigarette smoking tobacco"
         meaning: OMOP:4282779
       "OMOP:3011888":
-        description: "LOINC isoprostane_8_epi_pgf2a | Prostaglandin F2 alpha [Mass/volume] in Urine"
+        description: "LOINC isoprostane_8_epi_pgf2a | Prostaglandin F2 alpha [Mass/volume] in Urine | 8-epi-PGF2"
         meaning: OMOP:3011888
       "OMOP:36305170":
-        description: "LOINC lppla2_act | Lipoprotein associated phospholipase A2 [Enzymatic activity/volume] in Serum or Plasma"
+        description: "LOINC lppla2_act | Lipoprotein associated phospholipase A2 [Enzymatic activity/volume] in Serum or Plasma | LP-PLA2"
         meaning: OMOP:36305170
       "OMOP:37396400":
-        description: "SNOMED apnea_hypop_index | Apnea Hypopnea Index"
+        description: "SNOMED apnea_hypop_index | Apnea Hypopnea Index | AHI"
         meaning: OMOP:37396400
       "OMOP:4154347":
-        description: "SNOMED albumin_creatinine | Urine albumin/creatinine ratio measurement"
+        description: "SNOMED albumin_creatinine | Urine albumin/creatinine ratio measurement | uACR"
         meaning: OMOP:4154347
       "OMOP:35609491":
         description: "SNOMED alcohol_servings | Alcohol units consumed per week"
         meaning: OMOP:35609491
       "OMOP:4263457":
-        description: "SNOMED ast_sgot | Aspartate aminotransferase measurement"
+        description: "SNOMED ast_sgot | Aspartate aminotransferase measurement | AST SGOT"
         meaning: OMOP:4263457
       "OMOP:44805650":
         description: "SNOMED bilirubin_con | Conjugated bilirubin measurement"
@@ -4013,7 +4013,7 @@ enums:
         description: "SNOMED carotid_imt | Carotid intima media thickness"
         meaning: OMOP:4138462
       "OMOP:43054909":
-        description: "LOINC smoking | Tobacco smoking status"
+        description: "LOINC | Tobacco smoking status"
         meaning: OMOP:43054909
       "OMOP:37393605":
         description: "SNOMED d_dimer | D-dimer level"
@@ -4058,7 +4058,7 @@ enums:
         description: "SNOMED lympho_pct | Lymphocyte percent count in blood"
         meaning: OMOP:37208690
       "OMOP:3041450":
-        description: "LOINC lppla2_mass | Lipoprotein associated phospholipase A2 [Mass/volume] in Serum or Plasma"
+        description: "LOINC lppla2_mass | Lipoprotein associated phospholipase A2 [Mass/volume] in Serum or Plasma | LP-PLA2"
         meaning: OMOP:3041450
       "OMOP:37393850":
         description: "SNOMED mchc | MCHC - Mean corpuscular haemoglobin concentration"
@@ -4091,7 +4091,7 @@ enums:
         description: "SNOMED sodium_intak | Sodium intake"
         meaning: OMOP:606729
       "OMOP:37543055":
-        description: tnfr2
+        description: "CDISC | TNF Receptor 1B | tnfr2"
         meaning: OMOP:37543055
       "OMOP:4021291":
         description: "SNOMED troponin | Troponin measurement"
@@ -4108,18 +4108,9 @@ enums:
       "OMOP:4150326":
         description: "SNOMED fast_lipids | Fasting blood lipids"
         meaning: OMOP:4150326
-      "OMOP:4056965":
-        description: "SNOMED med_adher | Drug compliance good"
-        meaning: OMOP:4056965
-      "OMOP:3021806":
-        description: "LOINC med_use | History of Medication use"
-        meaning: OMOP:3021806
-      "OMOP:45772840":
-        description: "SNOMED pacem_stat | Implantable cardiac pacemaker"
-        meaning: OMOP:45772840
-      "OMOP:313459":
-        description: "SNOMED slp_ap_stat | Sleep apnea"
-        meaning: OMOP:313459
+      "OMOP:4144921":
+        description: "SNOMED pacemaker status | Implantation of cardiac pacemaker"
+        meaning: OMOP:4144921
       "OMOP:4152194":
         description: "SNOMED bp_systolic | Systolic blood pressure"
         meaning: OMOP:4152194
@@ -4138,294 +4129,290 @@ enums:
       "OMOP:3005600":
         description: "LOINC FVC percent predicted | FVC measured/predicted"
         meaning: OMOP:3005600
-
       "OMOP:4196583":
-        description: "SNOMED FEV1/FVC percent predicted | FEV1/FVC percent"
+        description: "SNOMED FEV1/FVC percent predicted | FEV1/FVC measured/predicted"
         meaning: OMOP:4196583
       "OMOP:2212186":
-        description: "CPT4 Albumin; serum, plasma or whole blood | Albumin; serum, plasma or whole blood"
+        description: "CPT4 Albumin; serum, plasma or whole blood"
         meaning: OMOP:2212186
       "OMOP:2212188":
-        description: "CPT4 Albumin; urine (eg, microalbumin), quantitative | Albumin; urine (eg, microalbumin), quantitative"
+        description: "CPT4 Albumin; urine (eg, microalbumin), quantitative"
         meaning: OMOP:2212188
       "OMOP:4146380":
-        description: "SNOMED Alanine aminotransferase measurement | Alanine aminotransferase measurement"
+        description: "SNOMED Alanine aminotransferase measurement"
         meaning: OMOP:4146380
       "OMOP:3010587":
-        description: "LOINC Aspartate aminotransferase [Presence] in Serum or Plasma | Aspartate aminotransferase [Presence] in Serum or Plasma"
+        description: "LOINC Aspartate aminotransferase [Presence] in Serum or Plasma"
         meaning: OMOP:3010587
       "OMOP:3006315":
-        description: "LOINC Basophils [#/volume] in Blood | Basophils [#/volume] in Blood"
+        description: "LOINC Basophils [#/volume] in Blood"
         meaning: OMOP:3006315
       "OMOP:3038553":
-        description: "LOINC Body mass index (BMI) [Ratio] | Body mass index (BMI) [Ratio]"
+        description: "LOINC Body mass index (BMI) [Ratio]"
         meaning: OMOP:3038553
       "OMOP:4307029":
-        description: "SNOMED Brain natriuretic peptide measurement | Brain natriuretic peptide measurement"
+        description: "SNOMED Brain natriuretic peptide measurement | BNP"
         meaning: OMOP:4307029
       "OMOP:3031569":
-        description: "LOINC Natriuretic peptide B [Mass/volume] in Blood | Natriuretic peptide B [Mass/volume] in Blood"
+        description: "LOINC Natriuretic peptide B [Mass/volume] in Blood | BNP"
         meaning: OMOP:3031569
       "OMOP:4099154":
-        description: "SNOMED Body weight | Body weight"
+        description: "SNOMED Body weight"
         meaning: OMOP:4099154
       "OMOP:4017361":
-        description: "SNOMED Blood urea nitrogen measurement | Blood urea nitrogen measurement"
+        description: "SNOMED Blood urea nitrogen measurement | BUN"
         meaning: OMOP:4017361
       "OMOP:4166120":
-        description: "SNOMED Calcium volume | Calcium volume"
+        description: "SNOMED Calcium volume"
         meaning: OMOP:4166120
       "OMOP:43020498":
-        description: "SNOMED Left carotid artery stenosis | Left carotid artery stenosis"
+        description: "SNOMED Left carotid artery stenosis"
         meaning: OMOP:43020498
       "OMOP:43021859":
-        description: "SNOMED Right carotid artery stenosis | Right carotid artery stenosis"
+        description: "SNOMED Right carotid artery stenosis"
         meaning: OMOP:43021859
       "OMOP:4209737":
-        description: "SNOMED Lymphocyte antigen CD40 | Lymphocyte antigen CD40"
+        description: "SNOMED Lymphocyte antigen CD40"
         meaning: OMOP:4209737
       "OMOP:4188066":
-        description: "SNOMED Chloride measurement | Chloride measurement"
+        description: "SNOMED Chloride measurement"
         meaning: OMOP:4188066
       "OMOP:3009024":
-        description: "LOINC Chloride [Moles/volume] in Specimen | Chloride [Moles/volume] in Specimen"
+        description: "LOINC Chloride [Moles/volume] in Specimen"
         meaning: OMOP:3009024
-      "OMOP:35811013":
-        description: Smoking status
-        meaning: OMOP:35811013
       "OMOP:2212294":
-        description: "CPT4 Creatinine; blood | Creatinine; blood"
+        description: "CPT4 Creatinine; blood"
         meaning: OMOP:2212294
       "OMOP:3051825":
-        description: "LOINC Creatinine [Mass/volume] in Blood | Creatinine [Mass/volume] in Blood"
+        description: "LOINC Creatinine [Mass/volume] in Blood"
         meaning: OMOP:3051825
       "OMOP:3016723":
-        description: "LOINC Creatinine [Mass/volume] in Serum or Plasma | Creatinine [Mass/volume] in Serum or Plasma"
+        description: "LOINC Creatinine [Mass/volume] in Serum or Plasma"
         meaning: OMOP:3016723
       "OMOP:3007081":
-        description: "LOINC Creatinine [Interpretation] in Urine | Creatinine [Interpretation] in Urine"
+        description: "LOINC Creatinine [Interpretation] in Urine"
         meaning: OMOP:3007081
       "OMOP:4136584":
-        description: "SNOMED Blood cystatin C measurement | Blood cystatin C measurement"
+        description: "SNOMED Blood cystatin C measurement"
         meaning: OMOP:4136584
       "OMOP:37172928":
-        description: "SNOMED D-dimer mass concentration in plasma | D-dimer mass concentration in plasma"
+        description: "SNOMED D-dimer mass concentration in plasma"
         meaning: OMOP:37172928
       "OMOP:3010372":
-        description: "LOINC E selectin [Mass/volume] in Blood | E selectin [Mass/volume] in Blood"
+        description: "LOINC E selectin [Mass/volume] in Blood"
         meaning: OMOP:3010372
       "OMOP:4022643":
-        description: "SNOMED Educational achievement | Educational achievement"
+        description: "SNOMED Educational achievement"
         meaning: OMOP:4022643
       "OMOP:3013115":
-        description: "LOINC Eosinophils [#/volume] in Blood | Eosinophils [#/volume] in Blood"
+        description: "LOINC Eosinophils [#/volume] in Blood"
         meaning: OMOP:3013115
       "OMOP:4217630":
-        description: "SNOMED Clotting factor VII assay | Clotting factor VII assay"
+        description: "SNOMED Clotting factor VII assay "
         meaning: OMOP:4217630
       "OMOP:4148587":
-        description: "SNOMED Factor VIII assay | Factor VIII assay"
+        description: "SNOMED Factor VIII assay"
         meaning: OMOP:4148587
       "OMOP:4076114":
-        description: "SNOMED Household income | Household income"
+        description: "SNOMED Household income"
         meaning: OMOP:4076114
       "OMOP:4176561":
-        description: "SNOMED Ferritin measurement | Ferritin measurement"
+        description: "SNOMED Ferritin measurement"
         meaning: OMOP:4176561
       "OMOP:3011961":
-        description: "LOINC Ferritin [Mass/volume] in Blood | Ferritin [Mass/volume] in Blood"
+        description: "LOINC Ferritin [Mass/volume] in Blood"
         meaning: OMOP:3011961
       "OMOP:3001122":
-        description: "LOINC Ferritin [Mass/volume] in Serum or Plasma | Ferritin [Mass/volume] in Serum or Plasma"
+        description: "LOINC Ferritin [Mass/volume] in Serum or Plasma"
         meaning: OMOP:3001122
       "OMOP:4094436":
-        description: "SNOMED Fibrinogen measurement | Fibrinogen measurement"
+        description: "SNOMED Fibrinogen measurement"
         meaning: OMOP:4094436
       "OMOP:4213477":
-        description: "SNOMED Glomerular filtration rate | Glomerular filtration rate"
+        description: "SNOMED Glomerular filtration rate"
         meaning: OMOP:4213477
       "OMOP:4149519":
-        description: "SNOMED Glucose measurement | Glucose measurement"
+        description: "SNOMED Glucose measurement"
         meaning: OMOP:4149519
       "OMOP:4076704":
-        description: "SNOMED High density lipoprotein measurement | High density lipoprotein measurement"
+        description: "SNOMED High density lipoprotein measurement | HDL"
         meaning: OMOP:4076704
       "OMOP:3027018":
-        description: "LOINC Heart rate | Heart rate"
+        description: "LOINC Heart rate"
         meaning: OMOP:3027018
       "OMOP:607590":
-        description: "SNOMED Body height | Body height"
+        description: "SNOMED Body height"
         meaning: OMOP:607590
       "OMOP:4151358":
-        description: "SNOMED Hematocrit determination | Hematocrit determination"
+        description: "SNOMED Hematocrit determination"
         meaning: OMOP:4151358
       "OMOP:4094758":
-        description: "SNOMED Hemoglobin finding | Hemoglobin finding"
+        description: "SNOMED Hemoglobin finding"
         meaning: OMOP:4094758
       "OMOP:4111665":
-        description: "SNOMED Hip circumference | Hip circumference"
+        description: "SNOMED Hip circumference"
         meaning: OMOP:4111665
       "OMOP:4060873":
-        description: "SNOMED Insulin measurement | Insulin measurement"
+        description: "SNOMED Insulin measurement"
         meaning: OMOP:4060873
       "OMOP:3022466":
-        description: "LOINC Insulin [Mass/volume] in Serum or Plasma | Insulin [Mass/volume] in Serum or Plasma"
+        description: "LOINC Insulin [Mass/volume] in Serum or Plasma"
         meaning: OMOP:3022466
       "OMOP:3011670":
-        description: "LOINC Insulin [Mass/volume] in Serum or Plasma --12 hours fasting | Insulin [Mass/volume] in Serum or Plasma --12 hours fasting"
+        description: "LOINC Insulin [Mass/volume] in Serum or Plasma --12 hours fasting"
         meaning: OMOP:3011670
       "OMOP:4332015":
-        description: "SNOMED IL-6 assay | IL-6 assay"
+        description: "SNOMED IL-6 assay | IL-6 assay | Interleukin 6"
         meaning: OMOP:4332015
       "OMOP:4012918":
-        description: "SNOMED Lactate dehydrogenase measurement | Lactate dehydrogenase measurement"
+        description: "SNOMED Lactate dehydrogenase measurement"
         meaning: OMOP:4012918
       "OMOP:1246795":
-        description: "SNOMED Lactate in blood | Lactate in blood"
+        description: "SNOMED Lactate in blood"
         meaning: OMOP:1246795
       "OMOP:4331302":
-        description: "SNOMED Low density lipoprotein measurement | Low density lipoprotein measurement"
+        description: "SNOMED Low density lipoprotein measurement | LDL"
         meaning: OMOP:4331302
       "OMOP:37208689":
-        description: "SNOMED Lymphocyte count in blood | Lymphocyte count in blood"
+        description: "SNOMED Lymphocyte count in blood"
         meaning: OMOP:37208689
       "OMOP:4254663":
-        description: "SNOMED Lymphocyte count | Lymphocyte count"
+        description: "SNOMED Lymphocyte count"
         meaning: OMOP:4254663
       "OMOP:1617307":
-        description: "LOINC Chemokine (C-C motif) ligand 2 [Mass/volume] in Serum or Plasma | Chemokine (C-C motif) ligand 2 [Mass/volume] in Serum or Plasma"
+        description: "LOINC Chemokine (C-C motif) ligand 2 [Mass/volume] in Serum or Plasma | CCL2"
         meaning: OMOP:1617307
       "OMOP:37168599":
-        description: "SNOMED Mean arterial pressure | Mean arterial pressure"
+        description: "SNOMED Mean arterial pressure"
         meaning: OMOP:37168599
       "OMOP:37398674":
-        description: "SNOMED MCH - Mean corpuscular haemoglobin | MCH - Mean corpuscular haemoglobin"
+        description: "SNOMED MCH - Mean corpuscular haemoglobin"
         meaning: OMOP:37398674
       "OMOP:37393851":
-        description: "SNOMED MCV - Mean corpuscular volume | MCV - Mean corpuscular volume"
+        description: "SNOMED MCV - Mean corpuscular volume"
         meaning: OMOP:37393851
       "OMOP:37397923":
-        description: "SNOMED Mean platelet volume | Mean platelet volume"
+        description: "SNOMED Mean platelet volume"
         meaning: OMOP:37397923
       "OMOP:40761106":
-        description: "LOINC Matrix metallopeptidase 9 [Mass/volume] in Blood | Matrix metallopeptidase 9 [Mass/volume] in Blood"
+        description: "LOINC Matrix metallopeptidase 9 [Mass/volume] in Blood | MMP9"
         meaning: OMOP:40761106
       "OMOP:3001604":
-        description: "LOINC Monocytes [#/volume] in Blood | Monocytes [#/volume] in Blood"
+        description: "LOINC Monocytes [#/volume] in Blood"
         meaning: OMOP:3001604
       "OMOP:1988928":
-        description: "LOINC Myeloperoxidase [Mass/volume] in Serum by Immunoassay | Myeloperoxidase [Mass/volume] in Serum by Immunoassay"
+        description: "LOINC Myeloperoxidase [Mass/volume] in Serum by Immunoassay"
         meaning: OMOP:1988928
       "OMOP:37208699":
-        description: "SNOMED Neutrophil count in blood | Neutrophil count in blood"
+        description: "SNOMED Neutrophil count in blood"
         meaning: OMOP:37208699
       "OMOP:4189511":
-        description: "SNOMED N terminal pro-brain natriuretic peptide level | N terminal pro-brain natriuretic peptide level"
+        description: "SNOMED N terminal pro-brain natriuretic peptide level"
         meaning: OMOP:4189511
       "OMOP:44812009":
-        description: "SNOMED Plasma N-terminal pro B-type natriuretic peptide concentration measurement | Plasma N-terminal pro B-type natriuretic peptide concentration measurement"
+        description: "SNOMED Plasma N-terminal pro B-type natriuretic peptide concentration measurement"
         meaning: OMOP:44812009
       "OMOP:44812008":
-        description: "SNOMED Serum N-terminal pro B-type natriuretic peptide concentration measurement | Serum N-terminal pro B-type natriuretic peptide concentration measurement"
+        description: "SNOMED Serum N-terminal pro B-type natriuretic peptide concentration measurement"
         meaning: OMOP:44812008
       "OMOP:3007356":
         description: "LOINC CD62P cells/cells in Blood | CD62P cells/100 cells in Blood"
         meaning: OMOP:3007356
       "OMOP:4245152":
-        description: "SNOMED Potassium measurement | Potassium measurement"
+        description: "SNOMED Potassium measurement"
         meaning: OMOP:4245152
       "OMOP:21490733":
-        description: "LOINC Potassium [Mass/volume] in Blood | Potassium [Mass/volume] in Blood"
+        description: "LOINC Potassium [Mass/volume] in Blood"
         meaning: OMOP:21490733
       "OMOP:4273021":
-        description: "SNOMED QRS complex - finding | QRS complex - finding"
+        description: "SNOMED QRS complex - finding"
         meaning: OMOP:4273021
       "OMOP:4030871":
-        description: "SNOMED Red blood cell count | Red blood cell count"
+        description: "SNOMED Red blood cell count"
         meaning: OMOP:4030871
       "OMOP:40768653":
-        description: "LOINC How many hours do you normally sleep [DI-PAD] | How many hours do you normally sleep [DI-PAD]"
+        description: "LOINC How many hours do you normally sleep [DI-PAD]"
         meaning: OMOP:40768653
       "OMOP:4097430":
-        description: "SNOMED Sodium measurement | Sodium measurement"
+        description: "SNOMED Sodium measurement"
         meaning: OMOP:4097430
       "OMOP:36303745":
-        description: "LOINC Sodium [Mass/volume] in Specimen | Sodium [Mass/volume] in Specimen"
+        description: "LOINC Sodium [Mass/volume] in Specimen"
         meaning: OMOP:36303745
       "OMOP:4020553":
-        description: "SNOMED Oxygen saturation measurement | Oxygen saturation measurement"
+        description: "SNOMED Oxygen saturation measurement"
         meaning: OMOP:4020553
       "OMOP:4302666":
-        description: "SNOMED Body temperature | Body temperature"
+        description: "SNOMED Body temperature"
         meaning: OMOP:4302666
       "OMOP:3004282":
         description: "LOINC Tumor necrosis factor alpha [Mass/volume] in Serum or Plasma | Tumor necrosis factor.alpha [Mass/volume] in Serum or Plasma"
         meaning: OMOP:3004282
       "OMOP:46235360":
-        description: "LOINC Tumor necrosis factor receptor superfamily member 1A [Mass/volume] in Serum or Plasma | Tumor necrosis factor receptor superfamily member 1A [Mass/volume] in Serum or Plasma"
+        description: "LOINC Tumor necrosis factor receptor superfamily member 1A [Mass/volume] in Serum or Plasma"
         meaning: OMOP:46235360
       "OMOP:4008265":
-        description: "SNOMED Total cholesterol measurement | Total cholesterol measurement"
+        description: "SNOMED Total cholesterol measurement"
         meaning: OMOP:4008265
       "OMOP:4032789":
-        description: "SNOMED Triglycerides measurement | Triglycerides measurement"
+        description: "SNOMED Triglycerides measurement"
         meaning: OMOP:4032789
       "OMOP:37311566":
-        description: "SNOMED Estimated intake of vegetable servings in 24 hours | Estimated intake of vegetable servings in 24 hours"
+        description: "SNOMED Estimated intake of vegetable servings in 24 hours"
         meaning: OMOP:37311566
       "OMOP:4252203":
-        description: "SNOMED von Willebrand factor antigen level | von Willebrand factor antigen level"
+        description: "SNOMED von Willebrand factor antigen level"
         meaning: OMOP:4252203
       "OMOP:4172830":
-        description: "SNOMED Waist circumference | Waist circumference"
+        description: "SNOMED Waist circumference"
         meaning: OMOP:4172830
       "OMOP:4298431":
-        description: "SNOMED White blood cell count | White blood cell count"
+        description: "SNOMED White blood cell count"
         meaning: OMOP:4298431
       "OMOP:3015183":
         description: "LOINC Erythrocyte sedimentation rate [Velocity] in Red Blood Cells | Erythrocyte sedimentation rate"
         meaning: OMOP:3015183
       "OMOP:4097822":
-        description: "SNOMED pH measurement, arterial | pH measurement, arterial"
+        description: "SNOMED pH measurement, arterial"
         meaning: OMOP:4097822
       "OMOP:4315792":
-        description: "SNOMED pH measurement, venous | pH measurement, venous"
+        description: "SNOMED pH measurement, venous"
         meaning: OMOP:4315792
       "OMOP:4041720":
-        description: "SNOMED Plasma fasting HDL cholesterol measurement | Plasma fasting HDL cholesterol measurement"
+        description: "SNOMED Plasma fasting HDL cholesterol measurement"
         meaning: OMOP:4041720
       "OMOP:4041721":
-        description: "SNOMED Plasma fasting LDL cholesterol measurement | Plasma fasting LDL cholesterol measurement"
+        description: "SNOMED Plasma fasting LDL cholesterol measurement"
         meaning: OMOP:4041721
       "OMOP:4041722":
-        description: "SNOMED Plasma fasting triglyceride measurement | Plasma fasting triglyceride measurement"
+        description: "SNOMED Plasma fasting triglyceride measurement"
         meaning: OMOP:4041722
       "OMOP:4041557":
-        description: "SNOMED Serum fasting HDL cholesterol measurement | Serum fasting HDL cholesterol measurement"
+        description: "SNOMED Serum fasting HDL cholesterol measurement"
         meaning: OMOP:4041557
       "OMOP:4042061":
-        description: "SNOMED Serum fasting LDL cholesterol measurement | Serum fasting LDL cholesterol measurement"
+        description: "SNOMED Serum fasting LDL cholesterol measurement"
         meaning: OMOP:4042061
       "OMOP:44791053":
-        description: "SNOMED Serum fasting total cholesterol | Serum fasting total cholesterol"
+        description: "SNOMED Serum fasting total cholesterol"
         meaning: OMOP:44791053
       "OMOP:4042590":
-        description: "SNOMED Serum fasting triglyceride measurement | Serum fasting triglyceride measurement"
+        description: "SNOMED Serum fasting triglyceride measurement"
         meaning: OMOP:4042590
       "OMOP:4190897":
-        description: "SNOMED Plasma total cholesterol level | Plasma total cholesterol level"
+        description: "SNOMED Plasma total cholesterol level"
         meaning: OMOP:4190897
       "OMOP:46235897":
-        description: "LOINC Albumin/Creatinine [Ratio] in 24 hour Urine | Albumin/Creatinine [Ratio] in 24 hour Urine"
+        description: "LOINC Albumin/Creatinine [Ratio] in 24 hour Urine"
         meaning: OMOP:46235897
       "OMOP:44811087":
         description: "SNOMED FVC post bronchodilator percentage change | FVC (forced vital capacity) post bronchodilator percentage change"
         meaning: OMOP:44811087
       "OMOP:44813037":
-        description: "SNOMED Forced expired volume in 1 second percentage change | Forced expired volume in 1 second percentage change"
+        description: "SNOMED Forced expired volume in 1 second percentage change"
         meaning: OMOP:44813037
       "OMOP:42868473":
-        description: "LOINC FEV1/FVC percent change | FEV1/FVC percent change"
+        description: "LOINC FEV1/FVC percent change"
         meaning: OMOP:42868473
       "OBA:2100046":
         description: "8-epi-prostaglandin F2alpha amount in urine | The amount of a 8-epi-prostaglandin F2alpha when measured in urine."
@@ -4500,7 +4487,7 @@ enums:
         description: "serum low-density lipoprotein cholesterol level | The amount of a low-density lipoprotein cholesterol when measured in blood serum."
         meaning: OBA:2045398
       "OBA:2045349":
-        description: "natriuretic peptides B proteolytic cleavage product level | The amount of a natriuretic peptides B proteolytic cleavage product when measured in anatomical entity."
+        description: "NT pro BNP | natriuretic peptides B proteolytic cleavage product level | The amount of a natriuretic peptides B proteolytic cleavage product when measured in anatomical entity."
         meaning: OBA:2045349
       "OBA:2050271":
         description: "tumor necrosis factor receptor superfamily member 11B amount | The amount of a tumor necrosis factor receptor superfamily member 11B when measured in anatomical entity."
@@ -4531,40 +4518,40 @@ enums:
         meaning: OBA:2100052
 
       "OMOP:3013682":
-        description: "LOINC Urea nitrogen [Mass/volume] in Serum or Plasma | Urea nitrogen [Mass/volume] in Serum or Plasma"
+        description: "LOINC Urea nitrogen [Mass/volume] in Serum or Plasma"
         meaning: OMOP:3013682
       "OMOP:3003205":
-        description: "LOINC Brachial artery Systolic blood pressure | Brachial artery Systolic blood pressure"
+        description: "LOINC Brachial artery Systolic blood pressure"
         meaning: OMOP:3003205
       "OMOP:3010404":
-        description: "LOINC Brachial artery Diastolic blood pressure | Brachial artery Diastolic blood pressure"
+        description: "LOINC Brachial artery Diastolic blood pressure"
         meaning: OMOP:3010404
       "OMOP:3016205":
-        description: "LOINC Systolic blood pressure Posterior tibial artery/Brachial artery | Systolic blood pressure Posterior tibial artery/Brachial artery"
+        description: "LOINC Systolic blood pressure Posterior tibial artery/Brachial artery"
         meaning: OMOP:3016205
       "OMOP:3010175":
-        description: "LOINC Systolic blood pressure Posterior tibial artery - right/Brachial artery | Systolic blood pressure Posterior tibial artery - right/Brachial artery"
+        description: "LOINC Systolic blood pressure Posterior tibial artery - right/Brachial artery"
         meaning: OMOP:3010175
       "OMOP:3000848":
-        description: "LOINC Systolic blood pressure Posterior tibial artery - left/Brachial artery | Systolic blood pressure Posterior tibial artery - left/Brachial artery"
+        description: "LOINC Systolic blood pressure Posterior tibial artery - left/Brachial artery"
         meaning: OMOP:3000848
       "OMOP:3021627":
-        description: "LOINC Systolic blood pressure Brachial artery - right/Brachial artery | Systolic blood pressure Brachial artery - right/Brachial artery"
+        description: "LOINC Systolic blood pressure Brachial artery - right/Brachial artery"
         meaning: OMOP:3021627
       "OMOP:3018586":
-        description: "LOINC Systolic blood pressure--sitting | Systolic blood pressure--sitting"
+        description: "LOINC Systolic blood pressure--sitting"
         meaning: OMOP:3018586
       "OMOP:3035856":
-        description: "LOINC Systolic blood pressure--standing | Systolic blood pressure--standing"
+        description: "LOINC Systolic blood pressure--standing"
         meaning: OMOP:3035856
       "OMOP:3009395":
-        description: "LOINC Systolic blood pressure--supine | Systolic blood pressure--supine"
+        description: "LOINC Systolic blood pressure--supine"
         meaning: OMOP:3009395
       "OBA:VT0000199":
         description: "blood albumin amount | The amount of a albumin type when measured in blood."
         meaning: OBA:VT0000199
       "OMOP:3014111":
-        description: "LOINC Lactate [Moles/volume] in Serum or Plasma | Lactate [Moles/volume] in Serum or Plasma"
+        description: "LOINC Lactate [Moles/volume] in Serum or Plasma"
         meaning: OMOP:3014111
 
   EducationalAttainmentObservationTypeEnum:

--- a/src/bdchm/schema/bdchm.yaml
+++ b/src/bdchm/schema/bdchm.yaml
@@ -4530,6 +4530,43 @@ enums:
         description: "waist to hip ratio | A compound attribute that is the ratio of waist circumference to hip circumference."
         meaning: OBA:2100052
 
+      "OMOP:3013682":
+        description: "LOINC Urea nitrogen [Mass/volume] in Serum or Plasma | Urea nitrogen [Mass/volume] in Serum or Plasma"
+        meaning: OMOP:3013682
+      "OMOP:3003205":
+        description: "LOINC Brachial artery Systolic blood pressure | Brachial artery Systolic blood pressure"
+        meaning: OMOP:3003205
+      "OMOP:3010404":
+        description: "LOINC Brachial artery Diastolic blood pressure | Brachial artery Diastolic blood pressure"
+        meaning: OMOP:3010404
+      "OMOP:3016205":
+        description: "LOINC Systolic blood pressure Posterior tibial artery/Brachial artery | Systolic blood pressure Posterior tibial artery/Brachial artery"
+        meaning: OMOP:3016205
+      "OMOP:3010175":
+        description: "LOINC Systolic blood pressure Posterior tibial artery - right/Brachial artery | Systolic blood pressure Posterior tibial artery - right/Brachial artery"
+        meaning: OMOP:3010175
+      "OMOP:3000848":
+        description: "LOINC Systolic blood pressure Posterior tibial artery - left/Brachial artery | Systolic blood pressure Posterior tibial artery - left/Brachial artery"
+        meaning: OMOP:3000848
+      "OMOP:3021627":
+        description: "LOINC Systolic blood pressure Brachial artery - right/Brachial artery | Systolic blood pressure Brachial artery - right/Brachial artery"
+        meaning: OMOP:3021627
+      "OMOP:3018586":
+        description: "LOINC Systolic blood pressure--sitting | Systolic blood pressure--sitting"
+        meaning: OMOP:3018586
+      "OMOP:3035856":
+        description: "LOINC Systolic blood pressure--standing | Systolic blood pressure--standing"
+        meaning: OMOP:3035856
+      "OMOP:3009395":
+        description: "LOINC Systolic blood pressure--supine | Systolic blood pressure--supine"
+        meaning: OMOP:3009395
+      "OBA:VT0000199":
+        description: "blood albumin amount | The amount of a albumin type when measured in blood."
+        meaning: OBA:VT0000199
+      "OMOP:3014111":
+        description: "LOINC Lactate [Moles/volume] in Serum or Plasma | Lactate [Moles/volume] in Serum or Plasma"
+        meaning: OMOP:3014111
+
   EducationalAttainmentObservationTypeEnum:
     description: Values describing the types of Education Attainment observed in an Observation.
     permissible_values:

--- a/src/bdchm/schema/bdchm.yaml
+++ b/src/bdchm/schema/bdchm.yaml
@@ -3791,743 +3791,743 @@ enums:
     permissible_values:
 
       "OBA:2050068":
-        description: Albumin in blood
+        description: "Albumin in blood | The amount of a albumin when measured in blood serum."
         meaning: OBA:2050068
       "OBA:2050075":
-        description: Alpha-1 antitrypsin in serum
+        description: "Alpha-1 antitrypsin in serum | The amount of a alpha-1-antitrypsin when measured in blood serum."
         meaning: OBA:2050075
       "OBA:2050062":
-        description: ALT SGPT
+        description: "ALT SGPT | The amount of a alanine aminotransferase when measured in blood serum."
         meaning: OBA:2050062
       "OBA:VT0002607":
-        description: basophils count
+        description: "basophils count | The amount of a basophil."
         meaning: OBA:VT0002607
       "OBA:VT0001569":
-        description: Bilirubin Unconjugated Indirect
+        description: "Bilirubin Unconjugated Indirect | The amount of a bilirubin IXalpha when measured in blood."
         meaning: OBA:VT0001569
       "OBA:2045455":
-        description: BMI
+        description: "BMI | A compound attribute that is the ratio of body mass to body height."
         meaning: OBA:2045455
       "OBA:2045303":
-        description: BNP
+        description: "BNP | The amount of a natriuretic peptides B when measured in anatomical entity."
         meaning: OBA:2045303
       "OBA:VT0001259":
-        description: Body weight
+        description: "Body weight | The mass of a multicellular organism."
         meaning: OBA:VT0001259
       "OBA:VT0005265":
-        description: BUN
+        description: "BUN | The amount of a urea when measured in blood."
         meaning: OBA:VT0005265
       "OBA:2052305":
-        description: CD40 in blood
+        description: "CD40 in blood | The amount of a CD40 ligand (human) when measured in blood."
         meaning: OBA:2052305
       "OBA:VT0003018":
-        description: Chloride in blood
+        description: "Chloride in blood | The amount of a chloride when measured in blood."
         meaning: OBA:VT0003018
       "OBA:2050096":
-        description: Creatinine in blood
+        description: "Creatinine in blood | The amount of a creatinine when measured in blood serum."
         meaning: OBA:2050096
       "OBA:VT0010540":
-        description: Creatinine in urine
+        description: "Creatinine in urine | The amount of a creatinine when measured in urine."
         meaning: OBA:VT0010540
       "OBA:2052375":
-        description: Cystatin C in blood
+        description: "Cystatin C in blood | The amount of a cystatin-C (human) when measured in blood."
         meaning: OBA:2052375
       "OBA:2052778":
-        description: E-selectin in blood
+        description: "E-selectin in blood | The amount of a E-selectin (human) when measured in blood."
         meaning: OBA:2052778
       "OBA:VT0002602":
-        description: Eosinophils count
+        description: "Eosinophils count | The amount of a eosinophil."
         meaning: OBA:VT0002602
       "OBA:2045235":
-        description: Erythrocyte Sed Rate
+        description: "Erythrocyte Sed Rate | The buoyancy of a erythrocyte."
         meaning: OBA:2045235
       "OBA:2041535":
-        description: Factor VII
+        description: "Factor VII | The amount of a coagulation factor VII when measured in blood serum."
         meaning: OBA:2041535
       "OBA:VT0010513":
-        description: Ferritin
+        description: "Ferritin | The amount of a ferritin complex when measured in blood."
         meaning: OBA:VT0010513
       "OBA:0000061":
-        description: Fibrinogen
+        description: "Fibrinogen | The amount of a fibrinogen complex."
         meaning: OBA:0000061
       "OBA:0003747":
-        description: GFR
+        description: "GFR | The rate of a glomerular filtration."
         meaning: OBA:0003747
       "OBA:VT0000188":
-        description: Glucose in blood
+        description: "Glucose in blood | The amount of a glucose when measured in blood."
         meaning: OBA:VT0000188
       "OBA:VT0000184":
-        description: HDL
+        description: "HDL | The amount of a high-density lipoprotein cholesterol when measured in blood."
         meaning: OBA:VT0000184
       "OBA:1001087":
-        description: Heart rate
+        description: "Heart rate | The rate of a heart contraction."
         meaning: OBA:1001087
       "OBA:VT0001253":
-        description: Height
+        description: "Height | The height of a multicellular organism."
         meaning: OBA:VT0001253
       "OBA:2045381":
-        description: Hematocrit
+        description: "Hematocrit | The volume of a erythrocyte when measured in blood."
         meaning: OBA:2045381
       "OBA:2060175":
-        description: Hemoglobin
+        description: "Hemoglobin | The amount of a hemoglobin when measured in blood."
         meaning: OBA:2060175
       "OBA:1000032":
-        description: Hip circumference
+        description: "Hip circumference | The circumference of a hip."
         meaning: OBA:1000032
       "OBA:2060174":
-        description: Insulin in blood
+        description: "Insulin in blood | The amount of a insulin when measured in blood."
         meaning: OBA:2060174
       "OBA:2052890":
-        description: interleukin 6 in blood
+        description: "interleukin 6 in blood | The amount of a interleukin-6 (human) when measured in blood."
         meaning: OBA:2052890
       "OBA:VT0010477":
-        description: Lactate Dehydrogenase LDH
+        description: "Lactate Dehydrogenase LDH | The amount of a lactate dehydrogenase complex when measured in blood."
         meaning: OBA:VT0010477
       "OBA:VT0010616":
-        description: Lactate in blood
+        description: "Lactate in blood | The amount of a lactate when measured in blood."
         meaning: OBA:VT0010616
       "OBA:VT0000181":
-        description: LDL
+        description: "LDL | The amount of a low-density lipoprotein cholesterol when measured in blood."
         meaning: OBA:VT0000181
       "OBA:VT0000717":
-        description: Lymphocytes count
+        description: "Lymphocytes count | The has number of of a lymphocyte."
         meaning: OBA:VT0000717
       "OBA:2052436":
-        description: MCP1 in blood
+        description: "MCP1 in blood | The amount of a C-C motif chemokine 2 (human) when measured in blood."
         meaning: OBA:2052436
       "OBA:VT2000000":
-        description: Mean arterial pressure
+        description: "Mean arterial pressure | The pressure of a arterial blood."
         meaning: OBA:VT2000000
       "OBA:2045301":
-        description: mean corpuscular hemoglobin
+        description: "mean corpuscular hemoglobin | The amount of a hemoglobin when measured in erythrocyte."
         meaning: OBA:2045301
       "OBA:0003460":
-        description: mean corpuscular volume
+        description: "mean corpuscular volume | The volume of a erythrocyte."
         meaning: OBA:0003460
       "OBA:0003277":
-        description: mean platelet volume
+        description: "mean platelet volume | The volume of a platelet."
         meaning: OBA:0003277
       "OBA:2052397":
-        description: MMP9 in blood
+        description: "MMP9 in blood | The amount of a matrix metalloproteinase-9 (human) when measured in blood."
         meaning: OBA:2052397
       "OBA:2052389":
-        description: Myeloperoxidase in blood
+        description: "Myeloperoxidase in blood | The amount of a myeloperoxidase (human) when measured in blood."
         meaning: OBA:2052389
       "OBA:VT0000222":
-        description: Neutrophils count
+        description: "Neutrophils count | The amount of a neutrophil."
         meaning: OBA:VT0000222
       "OBA:2052701":
-        description: P-selectin in blood
+        description: "P-selectin in blood | The amount of a P-selectin (human) when measured in blood."
         meaning: OBA:2052701
       "OBA:2045409":
-        description: pH of blood
+        description: "pH of blood | The acidity of a blood."
         meaning: OBA:2045409
       "OBA:VT0002668":
-        description: Potassium in blood
+        description: "Potassium in blood | The amount of a potassium atom when measured in blood."
         meaning: OBA:VT0002668
       "OBA:1001086":
-        description: QRS interval
+        description: "QRS interval | See also EFO_0005054"
         meaning: OBA:1001086
       "OBA:VT0001586":
-        description: Red blood cell count
+        description: "Red blood cell count | The amount of a erythrocyte."
         meaning: OBA:VT0001586
       "OBA:2040171":
-        description: Sleep hours
+        description: "Sleep hours | The duration of a sleep."
         meaning: OBA:2040171
       "OBA:VT0001776":
-        description: Sodium in blood
+        description: "Sodium in blood | The amount of a sodium atom when measured in blood."
         meaning: OBA:VT0001776
       "OBA:2045443":
-        description: SpO2
+        description: "SpO2 | The concentration of of a oxygen atom when measured in blood."
         meaning: OBA:2045443
       "OBA:VT0005535":
-        description: Temperature
+        description: "Temperature | The temperature of a multicellular organism."
         meaning: OBA:VT0005535
       "OBA:2051979":
-        description: TNFa in blood
+        description: "TNFa in blood | The amount of a tumor necrosis factor (human) when measured in blood."
         meaning: OBA:2051979
       "OBA:2051975":
-        description: TNFa-R1 in blood
+        description: "TNFa-R1 in blood | The amount of a tumor necrosis factor receptor superfamily member 1A (human) when measured in blood."
         meaning: OBA:2051975
       "OBA:VT0000180":
-        description: Total cholesterol in blood
+        description: "Total cholesterol in blood | The amount of a cholesterol when measured in blood."
         meaning: OBA:VT0000180
       "OBA:VT0002644":
-        description: Triglycerides in blood
+        description: "Triglycerides in blood | The amount of a triglyceride when measured in blood."
         meaning: OBA:VT0002644
       "OBA:2052741":
-        description: von Willebrand factor
+        description: "von Willebrand factor | The amount of a von Willebrand factor (human) when measured in blood."
         meaning: OBA:2052741
       "OBA:1001085":
-        description: Waist circumference
+        description: "Waist circumference | The circumference of a abdominal segment of trunk."
         meaning: OBA:1001085
       "OBA:VT0000217":
-        description: White blood cell count
+        description: "White blood cell count | The amount of a leukocyte."
         meaning: OBA:VT0000217
       "OBA:VT0002871":
-        description: Albumin in urine
+        description: "Albumin in urine | The amount of a albumin type when measured in urine."
         meaning: OBA:VT0002871
       "OBA:2041536":
-        description: Factor VIII
+        description: "Factor VIII | The amount of a coagulation factor VIII when measured in blood serum."
         meaning: OBA:2041536
       "OBA:VT0000223":
-        description: monocytes count
+        description: "monocytes count | The amount of a monocyte."
         meaning: OBA:VT0000223
       "OMOP:4282779":
-        description: Smoking status
+        description: "SNOMED Smoking status | Cigarette smoking tobacco"
         meaning: OMOP:4282779
       "OMOP:3011888":
-        description: isoprostane_8_epi_pgf2a
+        description: "LOINC isoprostane_8_epi_pgf2a | Prostaglandin F2 alpha [Mass/volume] in Urine"
         meaning: OMOP:3011888
       "OMOP:36305170":
-        description: lppla2_act
+        description: "LOINC lppla2_act | Lipoprotein associated phospholipase A2 [Enzymatic activity/volume] in Serum or Plasma"
         meaning: OMOP:36305170
       "OMOP:37396400":
-        description: apnea_hypop_index
+        description: "SNOMED apnea_hypop_index | Apnea Hypopnea Index"
         meaning: OMOP:37396400
       "OMOP:4154347":
-        description: albumin_creatinine
+        description: "SNOMED albumin_creatinine | Urine albumin/creatinine ratio measurement"
         meaning: OMOP:4154347
       "OMOP:35609491":
-        description: alcohol_servings
+        description: "SNOMED alcohol_servings | Alcohol units consumed per week"
         meaning: OMOP:35609491
       "OMOP:4263457":
-        description: ast_sgot
+        description: "SNOMED ast_sgot | Aspartate aminotransferase measurement"
         meaning: OMOP:4263457
       "OMOP:44805650":
-        description: bilirubin_con
+        description: "SNOMED bilirubin_con | Conjugated bilirubin measurement"
         meaning: OMOP:44805650
       "OMOP:4230543":
-        description: bilirubin_tot
+        description: "SNOMED bilirubin_tot | Bilirubin, total measurement"
         meaning: OMOP:4230543
       "OMOP:4112223":
-        description: bun_creatinine
+        description: "SNOMED bun_creatinine | BUN/Creatinine ratio"
         meaning: OMOP:4112223
       "OMOP:4208414":
-        description: crp
+        description: "SNOMED crp | C-reactive protein measurement"
         meaning: OMOP:4208414
       "OMOP:42872742":
-        description: cac_score
+        description: "SNOMED cac_score | Coronary artery calcium score"
         meaning: OMOP:42872742
       "OMOP:4138462":
-        description: carotid_imt
+        description: "SNOMED carotid_imt | Carotid intima media thickness"
         meaning: OMOP:4138462
       "OMOP:43054909":
-        description: smoking
+        description: "LOINC smoking | Tobacco smoking status"
         meaning: OMOP:43054909
       "OMOP:37393605":
-        description: d_dimer
+        description: "SNOMED d_dimer | D-dimer level"
         meaning: OMOP:37393605
       "OMOP:4154790":
-        description: bp_diastolic
+        description: "SNOMED bp_diastolic | Diastolic blood pressure"
         meaning: OMOP:4154790
       "OMOP:37208635":
-        description: egfr
+        description: "SNOMED egfr | Estimated glomerular filtration rate by laboratory calculation"
         meaning: OMOP:37208635
       "OMOP:4156660":
-        description: fast_gluc_bld
+        description: "SNOMED fast_gluc_bld | Fasting blood glucose measurement"
         meaning: OMOP:4156660
       "OMOP:4241837":
-        description: fev1
+        description: "SNOMED fev1 | Forced expired volume in 1 second"
         meaning: OMOP:4241837
       "OMOP:3011505":
-        description: fev1_fvc
+        description: "LOINC fev1_fvc | FEV1/FVC"
         meaning: OMOP:3011505
       "OMOP:21493059":
-        description: fruit_serving
+        description: "LOINC fruit_serving | Fruit servings 24 hour Estimated"
         meaning: OMOP:21493059
       "OMOP:4176265":
-        description: fvc
+        description: "SNOMED fvc | Forced vital capacity"
         meaning: OMOP:4176265
       "OMOP:4184637":
-        description: hemo_a1c
+        description: "SNOMED hemo_a1c | Hemoglobin A1c measurement"
         meaning: OMOP:4184637
       "OMOP:4284103":
-        description: icam
+        description: "SNOMED icam | Lymphocyte antigen CD54"
         meaning: OMOP:4284103
       "OMOP:3001804":
-        description: il1_beta
+        description: "LOINC il1_beta | Interleukin 1 beta [Mass/volume] in Serum or Plasma"
         meaning: OMOP:3001804
       "OMOP:3004578":
-        description: il10
+        description: "LOINC il10 | Interleukin 10 [Mass/volume] in Serum or Plasma"
         meaning: OMOP:3004578
       "OMOP:3043144":
-        description: il18
+        description: "LOINC il18 | Interleukin 18 [Mass/volume] in Serum or Plasma"
         meaning: OMOP:3043144
       "OMOP:37208690":
-        description: lympho_pct
+        description: "SNOMED lympho_pct | Lymphocyte percent count in blood"
         meaning: OMOP:37208690
       "OMOP:3041450":
-        description: lppla2_mass
+        description: "LOINC lppla2_mass | Lipoprotein associated phospholipase A2 [Mass/volume] in Serum or Plasma"
         meaning: OMOP:3041450
       "OMOP:37393850":
-        description: mchc
+        description: "SNOMED mchc | MCHC - Mean corpuscular haemoglobin concentration"
         meaning: OMOP:37393850
       "OMOP:37208698":
-        description: neutro_pct
+        description: "SNOMED neutro_pct | Neutrophil percent count in blood"
         meaning: OMOP:37208698
       "OMOP:1552124":
-        description: opg
+        description: "CPT4 opg | Oncology (pancreatic cancer), multiplex immunoassay of C5, C4, cystatin C, factor B, osteoprotegerin (OPG), gelsolin, IGFBP3, CA125 and multiplex electrochemiluminescent immunoassay (ECLIA) for CA19-9, serum, diagnostic algorithm reported qualitatively..."
         meaning: OMOP:1552124
       "OMOP:4267147":
-        description: platelet_ct
+        description: "SNOMED platelet_ct | Platelet count"
         meaning: OMOP:4267147
       "OMOP:4274406":
-        description: pr_ekg
+        description: "SNOMED pr_ekg | PR interval - finding"
         meaning: OMOP:4274406
       "OMOP:44791466":
-        description: procal
+        description: "SNOMED procal | Procalcitonin measurement"
         meaning: OMOP:44791466
       "OMOP:4273023":
-        description: qt_ekg
+        description: "SNOMED qt_ekg | QT interval - finding"
         meaning: OMOP:4273023
       "OMOP:37397924":
-        description: rdw
+        description: "SNOMED rdw | Red blood cell distribution width"
         meaning: OMOP:37397924
       "OMOP:4313591":
-        description: resp_rt
+        description: "SNOMED resp_rt | Respiratory rate"
         meaning: OMOP:4313591
       "OMOP:606729":
-        description: sodium_intak
+        description: "SNOMED sodium_intak | Sodium intake"
         meaning: OMOP:606729
       "OMOP:37543055":
         description: tnfr2
         meaning: OMOP:37543055
       "OMOP:4021291":
-        description: troponin
+        description: "SNOMED troponin | Troponin measurement"
         meaning: OMOP:4021291
       "OMOP:4042886":
-        description: vege_serving
+        description: "SNOMED vege_serving | Vegetable"
         meaning: OMOP:4042886
       "OMOP:4087501":
-        description: waist_hip
+        description: "SNOMED waist_hip | Waist/hip ratio"
         meaning: OMOP:4087501
       "OMOP:36303297":
-        description: cesd_score
+        description: "LOINC cesd_score | Center for Epidemiologic Studies Depression Scale-Revised total score [CESD-R]"
         meaning: OMOP:36303297
       "OMOP:4150326":
-        description: fast_lipids
+        description: "SNOMED fast_lipids | Fasting blood lipids"
         meaning: OMOP:4150326
       "OMOP:4056965":
-        description: med_adher
+        description: "SNOMED med_adher | Drug compliance good"
         meaning: OMOP:4056965
       "OMOP:3021806":
-        description: med_use
+        description: "LOINC med_use | History of Medication use"
         meaning: OMOP:3021806
       "OMOP:45772840":
-        description: pacem_stat
+        description: "SNOMED pacem_stat | Implantable cardiac pacemaker"
         meaning: OMOP:45772840
       "OMOP:313459":
-        description: slp_ap_stat
+        description: "SNOMED slp_ap_stat | Sleep apnea"
         meaning: OMOP:313459
       "OMOP:4152194":
-        description: bp_systolic
+        description: "SNOMED bp_systolic | Systolic blood pressure"
         meaning: OMOP:4152194
       "OMOP:3002094":
-        description: FVC predicted
+        description: "LOINC FVC predicted | Forced vital capacity [Volume] Respiratory system Predicted"
         meaning: OMOP:3002094
       "OMOP:3022891":
-        description: FEV1 predicted
+        description: "LOINC FEV1 predicted | FEV1 Predicted"
         meaning: OMOP:3022891
       "OMOP:3024594":
-        description: FEV1/FVC predicted
+        description: "LOINC FEV1/FVC predicted | FEV1/FVC Predicted"
         meaning: OMOP:3024594
       "OMOP:3011708":
-        description: FEV1 percent predicted
+        description: "LOINC FEV1 percent predicted | FEV1 measured/predicted"
         meaning: OMOP:3011708
       "OMOP:3005600":
-        description: FVC percent predicted
+        description: "LOINC FVC percent predicted | FVC measured/predicted"
         meaning: OMOP:3005600
 
       "OMOP:4196583":
-        description: FEV1/FVC percent predicted
+        description: "SNOMED FEV1/FVC percent predicted | FEV1/FVC percent"
         meaning: OMOP:4196583
       "OMOP:2212186":
-        description: "Albumin; serum, plasma or whole blood"
+        description: "CPT4 Albumin; serum, plasma or whole blood | Albumin; serum, plasma or whole blood"
         meaning: OMOP:2212186
       "OMOP:2212188":
-        description: "Albumin; urine (eg, microalbumin), quantitative"
+        description: "CPT4 Albumin; urine (eg, microalbumin), quantitative | Albumin; urine (eg, microalbumin), quantitative"
         meaning: OMOP:2212188
       "OMOP:4146380":
-        description: Alanine aminotransferase measurement
+        description: "SNOMED Alanine aminotransferase measurement | Alanine aminotransferase measurement"
         meaning: OMOP:4146380
       "OMOP:3010587":
-        description: Aspartate aminotransferase [Presence] in Serum or Plasma
+        description: "LOINC Aspartate aminotransferase [Presence] in Serum or Plasma | Aspartate aminotransferase [Presence] in Serum or Plasma"
         meaning: OMOP:3010587
       "OMOP:3006315":
-        description: Basophils [#/volume] in Blood
+        description: "LOINC Basophils [#/volume] in Blood | Basophils [#/volume] in Blood"
         meaning: OMOP:3006315
       "OMOP:3038553":
-        description: Body mass index (BMI) [Ratio]
+        description: "LOINC Body mass index (BMI) [Ratio] | Body mass index (BMI) [Ratio]"
         meaning: OMOP:3038553
       "OMOP:4307029":
-        description: Brain natriuretic peptide measurement
+        description: "SNOMED Brain natriuretic peptide measurement | Brain natriuretic peptide measurement"
         meaning: OMOP:4307029
       "OMOP:3031569":
-        description: Natriuretic peptide B [Mass/volume] in Blood
+        description: "LOINC Natriuretic peptide B [Mass/volume] in Blood | Natriuretic peptide B [Mass/volume] in Blood"
         meaning: OMOP:3031569
       "OMOP:4099154":
-        description: Body weight
+        description: "SNOMED Body weight | Body weight"
         meaning: OMOP:4099154
       "OMOP:4017361":
-        description: Blood urea nitrogen measurement
+        description: "SNOMED Blood urea nitrogen measurement | Blood urea nitrogen measurement"
         meaning: OMOP:4017361
       "OMOP:4166120":
-        description: Calcium volume
+        description: "SNOMED Calcium volume | Calcium volume"
         meaning: OMOP:4166120
       "OMOP:43020498":
-        description: Left carotid artery stenosis
+        description: "SNOMED Left carotid artery stenosis | Left carotid artery stenosis"
         meaning: OMOP:43020498
       "OMOP:43021859":
-        description: Right carotid artery stenosis
+        description: "SNOMED Right carotid artery stenosis | Right carotid artery stenosis"
         meaning: OMOP:43021859
       "OMOP:4209737":
-        description: Lymphocyte antigen CD40
+        description: "SNOMED Lymphocyte antigen CD40 | Lymphocyte antigen CD40"
         meaning: OMOP:4209737
       "OMOP:4188066":
-        description: Chloride measurement
+        description: "SNOMED Chloride measurement | Chloride measurement"
         meaning: OMOP:4188066
       "OMOP:3009024":
-        description: Chloride [Moles/volume] in Specimen
+        description: "LOINC Chloride [Moles/volume] in Specimen | Chloride [Moles/volume] in Specimen"
         meaning: OMOP:3009024
       "OMOP:35811013":
         description: Smoking status
         meaning: OMOP:35811013
       "OMOP:2212294":
-        description: "Creatinine; blood"
+        description: "CPT4 Creatinine; blood | Creatinine; blood"
         meaning: OMOP:2212294
       "OMOP:3051825":
-        description: Creatinine [Mass/volume] in Blood
+        description: "LOINC Creatinine [Mass/volume] in Blood | Creatinine [Mass/volume] in Blood"
         meaning: OMOP:3051825
       "OMOP:3016723":
-        description: Creatinine [Mass/volume] in Serum or Plasma
+        description: "LOINC Creatinine [Mass/volume] in Serum or Plasma | Creatinine [Mass/volume] in Serum or Plasma"
         meaning: OMOP:3016723
       "OMOP:3007081":
-        description: Creatinine [Interpretation] in Urine
+        description: "LOINC Creatinine [Interpretation] in Urine | Creatinine [Interpretation] in Urine"
         meaning: OMOP:3007081
       "OMOP:4136584":
-        description: Blood cystatin C measurement
+        description: "SNOMED Blood cystatin C measurement | Blood cystatin C measurement"
         meaning: OMOP:4136584
       "OMOP:37172928":
-        description: D-dimer mass concentration in plasma
+        description: "SNOMED D-dimer mass concentration in plasma | D-dimer mass concentration in plasma"
         meaning: OMOP:37172928
       "OMOP:3010372":
-        description: E selectin [Mass/volume] in Blood
+        description: "LOINC E selectin [Mass/volume] in Blood | E selectin [Mass/volume] in Blood"
         meaning: OMOP:3010372
       "OMOP:4022643":
-        description: Educational achievement
+        description: "SNOMED Educational achievement | Educational achievement"
         meaning: OMOP:4022643
       "OMOP:3013115":
-        description: Eosinophils [#/volume] in Blood
+        description: "LOINC Eosinophils [#/volume] in Blood | Eosinophils [#/volume] in Blood"
         meaning: OMOP:3013115
       "OMOP:4217630":
-        description: Clotting factor VII assay
+        description: "SNOMED Clotting factor VII assay | Clotting factor VII assay"
         meaning: OMOP:4217630
       "OMOP:4148587":
-        description: Factor VIII assay
+        description: "SNOMED Factor VIII assay | Factor VIII assay"
         meaning: OMOP:4148587
       "OMOP:4076114":
-        description: Household income
+        description: "SNOMED Household income | Household income"
         meaning: OMOP:4076114
       "OMOP:4176561":
-        description: Ferritin measurement
+        description: "SNOMED Ferritin measurement | Ferritin measurement"
         meaning: OMOP:4176561
       "OMOP:3011961":
-        description: Ferritin [Mass/volume] in Blood
+        description: "LOINC Ferritin [Mass/volume] in Blood | Ferritin [Mass/volume] in Blood"
         meaning: OMOP:3011961
       "OMOP:3001122":
-        description: Ferritin [Mass/volume] in Serum or Plasma
+        description: "LOINC Ferritin [Mass/volume] in Serum or Plasma | Ferritin [Mass/volume] in Serum or Plasma"
         meaning: OMOP:3001122
       "OMOP:4094436":
-        description: Fibrinogen measurement
+        description: "SNOMED Fibrinogen measurement | Fibrinogen measurement"
         meaning: OMOP:4094436
       "OMOP:4213477":
-        description: Glomerular filtration rate
+        description: "SNOMED Glomerular filtration rate | Glomerular filtration rate"
         meaning: OMOP:4213477
       "OMOP:4149519":
-        description: Glucose measurement
+        description: "SNOMED Glucose measurement | Glucose measurement"
         meaning: OMOP:4149519
       "OMOP:4076704":
-        description: High density lipoprotein measurement
+        description: "SNOMED High density lipoprotein measurement | High density lipoprotein measurement"
         meaning: OMOP:4076704
       "OMOP:3027018":
-        description: Heart rate
+        description: "LOINC Heart rate | Heart rate"
         meaning: OMOP:3027018
       "OMOP:607590":
-        description: Body height
+        description: "SNOMED Body height | Body height"
         meaning: OMOP:607590
       "OMOP:4151358":
-        description: Hematocrit determination
+        description: "SNOMED Hematocrit determination | Hematocrit determination"
         meaning: OMOP:4151358
       "OMOP:4094758":
-        description: Hemoglobin finding
+        description: "SNOMED Hemoglobin finding | Hemoglobin finding"
         meaning: OMOP:4094758
       "OMOP:4111665":
-        description: Hip circumference
+        description: "SNOMED Hip circumference | Hip circumference"
         meaning: OMOP:4111665
       "OMOP:4060873":
-        description: Insulin measurement
+        description: "SNOMED Insulin measurement | Insulin measurement"
         meaning: OMOP:4060873
       "OMOP:3022466":
-        description: Insulin [Mass/volume] in Serum or Plasma
+        description: "LOINC Insulin [Mass/volume] in Serum or Plasma | Insulin [Mass/volume] in Serum or Plasma"
         meaning: OMOP:3022466
       "OMOP:3011670":
-        description: Insulin [Mass/volume] in Serum or Plasma --12 hours fasting
+        description: "LOINC Insulin [Mass/volume] in Serum or Plasma --12 hours fasting | Insulin [Mass/volume] in Serum or Plasma --12 hours fasting"
         meaning: OMOP:3011670
       "OMOP:4332015":
-        description: IL-6 assay
+        description: "SNOMED IL-6 assay | IL-6 assay"
         meaning: OMOP:4332015
       "OMOP:4012918":
-        description: Lactate dehydrogenase measurement
+        description: "SNOMED Lactate dehydrogenase measurement | Lactate dehydrogenase measurement"
         meaning: OMOP:4012918
       "OMOP:1246795":
-        description: Lactate in blood
+        description: "SNOMED Lactate in blood | Lactate in blood"
         meaning: OMOP:1246795
       "OMOP:4331302":
-        description: Low density lipoprotein measurement
+        description: "SNOMED Low density lipoprotein measurement | Low density lipoprotein measurement"
         meaning: OMOP:4331302
       "OMOP:37208689":
-        description: Lymphocyte count in blood
+        description: "SNOMED Lymphocyte count in blood | Lymphocyte count in blood"
         meaning: OMOP:37208689
       "OMOP:4254663":
-        description: Lymphocyte count
+        description: "SNOMED Lymphocyte count | Lymphocyte count"
         meaning: OMOP:4254663
       "OMOP:1617307":
-        description: Chemokine (C-C motif) ligand 2 [Mass/volume] in Serum or Plasma
+        description: "LOINC Chemokine (C-C motif) ligand 2 [Mass/volume] in Serum or Plasma | Chemokine (C-C motif) ligand 2 [Mass/volume] in Serum or Plasma"
         meaning: OMOP:1617307
       "OMOP:37168599":
-        description: Mean arterial pressure
+        description: "SNOMED Mean arterial pressure | Mean arterial pressure"
         meaning: OMOP:37168599
       "OMOP:37398674":
-        description: MCH - Mean corpuscular haemoglobin
+        description: "SNOMED MCH - Mean corpuscular haemoglobin | MCH - Mean corpuscular haemoglobin"
         meaning: OMOP:37398674
       "OMOP:37393851":
-        description: MCV - Mean corpuscular volume
+        description: "SNOMED MCV - Mean corpuscular volume | MCV - Mean corpuscular volume"
         meaning: OMOP:37393851
       "OMOP:37397923":
-        description: Mean platelet volume
+        description: "SNOMED Mean platelet volume | Mean platelet volume"
         meaning: OMOP:37397923
       "OMOP:40761106":
-        description: Matrix metallopeptidase 9 [Mass/volume] in Blood
+        description: "LOINC Matrix metallopeptidase 9 [Mass/volume] in Blood | Matrix metallopeptidase 9 [Mass/volume] in Blood"
         meaning: OMOP:40761106
       "OMOP:3001604":
-        description: Monocytes [#/volume] in Blood
+        description: "LOINC Monocytes [#/volume] in Blood | Monocytes [#/volume] in Blood"
         meaning: OMOP:3001604
       "OMOP:1988928":
-        description: Myeloperoxidase [Mass/volume] in Serum by Immunoassay
+        description: "LOINC Myeloperoxidase [Mass/volume] in Serum by Immunoassay | Myeloperoxidase [Mass/volume] in Serum by Immunoassay"
         meaning: OMOP:1988928
       "OMOP:37208699":
-        description: Neutrophil count in blood
+        description: "SNOMED Neutrophil count in blood | Neutrophil count in blood"
         meaning: OMOP:37208699
       "OMOP:4189511":
-        description: N terminal pro-brain natriuretic peptide level
+        description: "SNOMED N terminal pro-brain natriuretic peptide level | N terminal pro-brain natriuretic peptide level"
         meaning: OMOP:4189511
       "OMOP:44812009":
-        description: Plasma N-terminal pro B-type natriuretic peptide concentration measurement
+        description: "SNOMED Plasma N-terminal pro B-type natriuretic peptide concentration measurement | Plasma N-terminal pro B-type natriuretic peptide concentration measurement"
         meaning: OMOP:44812009
       "OMOP:44812008":
-        description: Serum N-terminal pro B-type natriuretic peptide concentration measurement
+        description: "SNOMED Serum N-terminal pro B-type natriuretic peptide concentration measurement | Serum N-terminal pro B-type natriuretic peptide concentration measurement"
         meaning: OMOP:44812008
       "OMOP:3007356":
-        description: CD62P cells/cells in Blood
+        description: "LOINC CD62P cells/cells in Blood | CD62P cells/100 cells in Blood"
         meaning: OMOP:3007356
       "OMOP:4245152":
-        description: Potassium measurement
+        description: "SNOMED Potassium measurement | Potassium measurement"
         meaning: OMOP:4245152
       "OMOP:21490733":
-        description: Potassium [Mass/volume] in Blood
+        description: "LOINC Potassium [Mass/volume] in Blood | Potassium [Mass/volume] in Blood"
         meaning: OMOP:21490733
       "OMOP:4273021":
-        description: QRS complex - finding
+        description: "SNOMED QRS complex - finding | QRS complex - finding"
         meaning: OMOP:4273021
       "OMOP:4030871":
-        description: Red blood cell count
+        description: "SNOMED Red blood cell count | Red blood cell count"
         meaning: OMOP:4030871
       "OMOP:40768653":
-        description: How many hours do you normally sleep [DI-PAD]
+        description: "LOINC How many hours do you normally sleep [DI-PAD] | How many hours do you normally sleep [DI-PAD]"
         meaning: OMOP:40768653
       "OMOP:4097430":
-        description: Sodium measurement
+        description: "SNOMED Sodium measurement | Sodium measurement"
         meaning: OMOP:4097430
       "OMOP:36303745":
-        description: Sodium [Mass/volume] in Specimen
+        description: "LOINC Sodium [Mass/volume] in Specimen | Sodium [Mass/volume] in Specimen"
         meaning: OMOP:36303745
       "OMOP:4020553":
-        description: Oxygen saturation measurement
+        description: "SNOMED Oxygen saturation measurement | Oxygen saturation measurement"
         meaning: OMOP:4020553
       "OMOP:4302666":
-        description: Body temperature
+        description: "SNOMED Body temperature | Body temperature"
         meaning: OMOP:4302666
       "OMOP:3004282":
-        description: Tumor necrosis factor alpha [Mass/volume] in Serum or Plasma
+        description: "LOINC Tumor necrosis factor alpha [Mass/volume] in Serum or Plasma | Tumor necrosis factor.alpha [Mass/volume] in Serum or Plasma"
         meaning: OMOP:3004282
       "OMOP:46235360":
-        description: Tumor necrosis factor receptor superfamily member 1A [Mass/volume] in Serum or Plasma
+        description: "LOINC Tumor necrosis factor receptor superfamily member 1A [Mass/volume] in Serum or Plasma | Tumor necrosis factor receptor superfamily member 1A [Mass/volume] in Serum or Plasma"
         meaning: OMOP:46235360
       "OMOP:4008265":
-        description: Total cholesterol measurement
+        description: "SNOMED Total cholesterol measurement | Total cholesterol measurement"
         meaning: OMOP:4008265
       "OMOP:4032789":
-        description: Triglycerides measurement
+        description: "SNOMED Triglycerides measurement | Triglycerides measurement"
         meaning: OMOP:4032789
       "OMOP:37311566":
-        description: Estimated intake of vegetable servings in 24 hours
+        description: "SNOMED Estimated intake of vegetable servings in 24 hours | Estimated intake of vegetable servings in 24 hours"
         meaning: OMOP:37311566
       "OMOP:4252203":
-        description: von Willebrand factor antigen level
+        description: "SNOMED von Willebrand factor antigen level | von Willebrand factor antigen level"
         meaning: OMOP:4252203
       "OMOP:4172830":
-        description: Waist circumference
+        description: "SNOMED Waist circumference | Waist circumference"
         meaning: OMOP:4172830
       "OMOP:4298431":
-        description: White blood cell count
+        description: "SNOMED White blood cell count | White blood cell count"
         meaning: OMOP:4298431
       "OMOP:3015183":
-        description: Erythrocyte sedimentation rate [Velocity] in Red Blood Cells
+        description: "LOINC Erythrocyte sedimentation rate [Velocity] in Red Blood Cells | Erythrocyte sedimentation rate"
         meaning: OMOP:3015183
       "OMOP:4097822":
-        description: "pH measurement, arterial"
+        description: "SNOMED "pH measurement, arterial" | pH measurement, arterial"
         meaning: OMOP:4097822
       "OMOP:4315792":
-        description: "pH measurement, venous"
+        description: "SNOMED "pH measurement, venous" | pH measurement, venous"
         meaning: OMOP:4315792
       "OMOP:4041720":
-        description: Plasma fasting HDL cholesterol measurement
+        description: "SNOMED Plasma fasting HDL cholesterol measurement | Plasma fasting HDL cholesterol measurement"
         meaning: OMOP:4041720
       "OMOP:4041721":
-        description: Plasma fasting LDL cholesterol measurement
+        description: "SNOMED Plasma fasting LDL cholesterol measurement | Plasma fasting LDL cholesterol measurement"
         meaning: OMOP:4041721
       "OMOP:4041722":
-        description: Plasma fasting triglyceride measurement
+        description: "SNOMED Plasma fasting triglyceride measurement | Plasma fasting triglyceride measurement"
         meaning: OMOP:4041722
       "OMOP:4041557":
-        description: Serum fasting HDL cholesterol measurement
+        description: "SNOMED Serum fasting HDL cholesterol measurement | Serum fasting HDL cholesterol measurement"
         meaning: OMOP:4041557
       "OMOP:4042061":
-        description: Serum fasting LDL cholesterol measurement
+        description: "SNOMED Serum fasting LDL cholesterol measurement | Serum fasting LDL cholesterol measurement"
         meaning: OMOP:4042061
       "OMOP:44791053":
-        description: Serum fasting total cholesterol
+        description: "SNOMED Serum fasting total cholesterol | Serum fasting total cholesterol"
         meaning: OMOP:44791053
       "OMOP:4042590":
-        description: Serum fasting triglyceride measurement
+        description: "SNOMED Serum fasting triglyceride measurement | Serum fasting triglyceride measurement"
         meaning: OMOP:4042590
       "OMOP:4190897":
-        description: Plasma total cholesterol level
+        description: "SNOMED Plasma total cholesterol level | Plasma total cholesterol level"
         meaning: OMOP:4190897
       "OMOP:46235897":
-        description: Albumin/Creatinine [Ratio] in 24 hour Urine
+        description: "LOINC Albumin/Creatinine [Ratio] in 24 hour Urine | Albumin/Creatinine [Ratio] in 24 hour Urine"
         meaning: OMOP:46235897
       "OMOP:44811087":
-        description: FVC post bronchodilator percentage change
+        description: "SNOMED FVC post bronchodilator percentage change | FVC (forced vital capacity) post bronchodilator percentage change"
         meaning: OMOP:44811087
       "OMOP:44813037":
-        description: Forced expired volume in 1 second percentage change
+        description: "SNOMED Forced expired volume in 1 second percentage change | Forced expired volume in 1 second percentage change"
         meaning: OMOP:44813037
       "OMOP:42868473":
-        description: FEV1/FVC percent change
+        description: "LOINC FEV1/FVC percent change | FEV1/FVC percent change"
         meaning: OMOP:42868473
       "OBA:2100046":
-        description: 8-epi-prostaglandin F2alpha amount in urine
+        description: "8-epi-prostaglandin F2alpha amount in urine | The amount of a 8-epi-prostaglandin F2alpha when measured in urine."
         meaning: OBA:2100046
       "OBA:2100055":
-        description: amount of 1-alkyl-2-acetylglycerophosphocholine esterase activity in blood
+        description: "amount of 1-alkyl-2-acetylglycerophosphocholine esterase activity in blood | The amount of a 1-alkyl-2-acetylglycerophosphocholine esterase activity when measured in blood."
         meaning: OBA:2100055
       "OBA:2100053":
-        description: albumin to creatinine ratio in urine
+        description: "albumin to creatinine ratio in urine | A compound attribute that is the ratio of urine albumin amount to urine creatinine amount."
         meaning: OBA:2100053
       "OBA:2060178":
-        description: amount of albumin in blood
+        description: "amount of albumin in blood | The amount of a albumin when measured in blood."
         meaning: OBA:2060178
       "OBA:VT0001573":
-        description: blood alanine transaminase amount
+        description: "blood alanine transaminase amount | The amount of a alanine aminotransferase when measured in blood."
         meaning: OBA:VT0001573
       "OBA:2100047":
-        description: aspartate aminotransferase (human) amount in blood
+        description: "aspartate aminotransferase (human) amount in blood | The amount of a aspartate aminotransferase (human) when measured in blood."
         meaning: OBA:2100047
       "OBA:2100274":
-        description: natriuretic peptides B amount in blood
+        description: "natriuretic peptides B amount in blood | The amount of a natriuretic peptides B when measured in blood."
         meaning: OBA:2100274
       "OBA:2100054":
-        description: urea nitrogen to creatinine ratio in blood
+        description: "urea nitrogen to creatinine ratio in blood | A compound attribute that is the ratio of blood urea nitrogen amount to blood creatinine amount."
         meaning: OBA:2100054
       "NCIT:C80425":
-        description: Coronary Calcium Score
+        description: "Coronary Calcium Score | A quantitative value that is the compilation of assessed size and densities of calcium deposits throughout the coronary tree."
         meaning: NCIT:C80425
       "OBA:2090004":
-        description: carotid artery intima-media region thickness
+        description: "carotid artery intima-media region thickness | The thickness of a carotid artery intima-media region."
         meaning: OBA:2090004
       "OBA:2050108":
-        description: carotid artery thickness
+        description: "carotid artery thickness | The thickness of a carotid artery segment."
         meaning: OBA:2050108
       "OBA:VT0005328":
-        description: blood creatinine amount
+        description: "blood creatinine amount | The amount of a creatinine when measured in blood."
         meaning: OBA:VT0005328
       "OBA:2100048":
-        description: D-dimer (human) amount in blood
+        description: "D-dimer (human) amount in blood | The amount of a D-dimer (human) when measured in blood."
         meaning: OBA:2100048
       "NCIT:C110935":
-        description: Estimated Glomerular Filtration Rate
+        description: "Estimated Glomerular Filtration Rate | A laboratory test that estimates kidney function. It is calculated using an individual's serum creatinine measurement, age, sex, and race. Actual results are reported when the estimated glomerular filtration rate is less than 60 ml/min."
         meaning: NCIT:C110935
       "OBA:2050626":
-        description: level of coagulation factor VII in blood
+        description: "level of coagulation factor VII in blood | The amount of a coagulation factor VII when measured in blood."
         meaning: OBA:2050626
       "OBA:2090000":
-        description: level of glucose in blood during fasting
+        description: "level of glucose in blood during fasting | The amount of a glucose when measured in blood during fasting."
         meaning: OBA:2090000
       "CMO:0000241":
-        description: forced expiratory volume to forced vital capacity ratio
+        description: "forced expiratory volume to forced vital capacity ratio | The comparison of forced expiratory volume to forced vital capacity expressed as ratio or percentage."
         meaning: CMO:0000241
       "CMO:0000251":
-        description: forced vital capacity (FVC)
+        description: "forced vital capacity (FVC) | The volume of air that can be forcibly expelled from a maximally inflated lung."
         meaning: CMO:0000251
       "OBA:2045397":
-        description: serum high-density lipoprotein cholesterol level
+        description: "serum high-density lipoprotein cholesterol level | The amount of a high-density lipoprotein cholesterol when measured in blood serum."
         meaning: OBA:2045397
       "OBA:2100049":
-        description: hemoglobin A1c amount in blood
+        description: "hemoglobin A1c amount in blood | The amount of a hemoglobin A1c when measured in blood."
         meaning: OBA:2100049
       "OBA:2090001":
-        description: level of insulin in blood during fasting
+        description: "level of insulin in blood during fasting | The amount of a insulin when measured in blood during fasting."
         meaning: OBA:2090001
       "OBA:VT0008640":
-        description: blood interleukin-1 beta amount
+        description: "blood interleukin-1 beta amount | The amount of a interleukin-1 beta when measured in blood."
         meaning: OBA:VT0008640
       "OBA:VT0008590":
-        description: blood interleukin-10 amount
+        description: "blood interleukin-10 amount | The amount of a interleukin-10 when measured in blood."
         meaning: OBA:VT0008590
       "OBA:2045398":
-        description: serum low-density lipoprotein cholesterol level
+        description: "serum low-density lipoprotein cholesterol level | The amount of a low-density lipoprotein cholesterol when measured in blood serum."
         meaning: OBA:2045398
       "OBA:2045349":
-        description: natriuretic peptides B proteolytic cleavage product level
+        description: "natriuretic peptides B proteolytic cleavage product level | The amount of a natriuretic peptides B proteolytic cleavage product when measured in anatomical entity."
         meaning: OBA:2045349
       "OBA:2050271":
-        description: tumor necrosis factor receptor superfamily member 11B amount
+        description: "tumor necrosis factor receptor superfamily member 11B amount | The amount of a tumor necrosis factor receptor superfamily member 11B when measured in anatomical entity."
         meaning: OBA:2050271
       "OBA:VT0003179":
-        description: platelet quantity
+        description: "platelet quantity | The amount of a platelet."
         meaning: OBA:VT0003179
       "CMO:0000233":
-        description: PR interval
+        description: "PR interval | Time between the beginning of the P wave to the beginning of the QRS complex, reflects the time the electrical impulse takes to travel from the sinus node through the AV node and entering the ventricles, used as an estimate of AV node function."
         meaning: CMO:0000233
       "CMO:0000235":
-        description: QT interval
+        description: "QT interval | An interval measured from the onset of the QRS wave complex to the offset of the T wave."
         meaning: CMO:0000235
       "EFO:0009188":
-        description: Red cell distribution width
+        description: "Red cell distribution width | Red blood cell distribution width (RDW or RDW-CV or RCDW and RDW-SD) is a measure of the range of variation of red blood cell (RBC) volume that is reported as part of a standard complete blood count. Usually red blood cells are a standard size of about 6-8 μm in diameter. Certain disorders, however, cause a significant variation in cell size. Higher RDW values indicate greater variation in size. Normal reference range of RDW-CV in human red blood cells is 11.5-14.5%.[1] If anemia is observed, RDW test results are often used together with mean corpuscular volume (MCV) results to determine the possible causes of the anemia. It is mainly used to differentiate an anemia of mixed causes from an anemia of a single cause."
         meaning: EFO:0009188
       "EFO:0020080":
-        description: dietary sodium intake measurement
+        description: "dietary sodium intake measurement | Quantification of dietary sodium intake."
         meaning: EFO:0020080
       "OBA:VT0000183":
-        description: blood pressure trait
+        description: "blood pressure trait | The pressure of a blood."
         meaning: OBA:VT0000183
       "OBA:2100051":
-        description: troponin complex amount in blood
+        description: "troponin complex amount in blood | The amount of a troponin complex when measured in blood."
         meaning: OBA:2100051
       "OBA:2100052":
-        description: waist to hip ratio
+        description: "waist to hip ratio | A compound attribute that is the ratio of waist circumference to hip circumference."
         meaning: OBA:2100052
 
   EducationalAttainmentObservationTypeEnum:

--- a/src/bdchm/schema/bdchm.yaml
+++ b/src/bdchm/schema/bdchm.yaml
@@ -4310,10 +4310,10 @@ enums:
         description: "SNOMED N terminal pro-brain natriuretic peptide level"
         meaning: OMOP:4189511
       "OMOP:44812009":
-        description: "SNOMED Plasma N-terminal pro B-type natriuretic peptide concentration measurement"
+        description: "SNOMED Plasma N-terminal pro B-type natriuretic peptide concentration measurement | NT pro BNP"
         meaning: OMOP:44812009
       "OMOP:44812008":
-        description: "SNOMED Serum N-terminal pro B-type natriuretic peptide concentration measurement"
+        description: "SNOMED Serum N-terminal pro B-type natriuretic peptide concentration measurement | NT pro BNP"
         meaning: OMOP:44812008
       "OMOP:3007356":
         description: "LOINC CD62P cells/cells in Blood | CD62P cells/100 cells in Blood"
@@ -4328,7 +4328,7 @@ enums:
         description: "SNOMED QRS complex - finding"
         meaning: OMOP:4273021
       "OMOP:4030871":
-        description: "SNOMED Red blood cell count"
+        description: "SNOMED Red blood cell count | RBC"
         meaning: OMOP:4030871
       "OMOP:40768653":
         description: "LOINC How many hours do you normally sleep [DI-PAD]"
@@ -4340,16 +4340,16 @@ enums:
         description: "LOINC Sodium [Mass/volume] in Specimen"
         meaning: OMOP:36303745
       "OMOP:4020553":
-        description: "SNOMED Oxygen saturation measurement"
+        description: "SNOMED Oxygen saturation measurement | SpO2"
         meaning: OMOP:4020553
       "OMOP:4302666":
         description: "SNOMED Body temperature"
         meaning: OMOP:4302666
       "OMOP:3004282":
-        description: "LOINC Tumor necrosis factor alpha [Mass/volume] in Serum or Plasma | Tumor necrosis factor.alpha [Mass/volume] in Serum or Plasma"
+        description: "LOINC Tumor necrosis factor alpha [Mass/volume] in Serum or Plasma | Tumor necrosis factor.alpha [Mass/volume] in Serum or Plasma | TNFa"
         meaning: OMOP:3004282
       "OMOP:46235360":
-        description: "LOINC Tumor necrosis factor receptor superfamily member 1A [Mass/volume] in Serum or Plasma"
+        description: "LOINC Tumor necrosis factor receptor superfamily member 1A [Mass/volume] in Serum or Plasma | TNFa-R1"
         meaning: OMOP:46235360
       "OMOP:4008265":
         description: "SNOMED Total cholesterol measurement"
@@ -4367,7 +4367,7 @@ enums:
         description: "SNOMED Waist circumference"
         meaning: OMOP:4172830
       "OMOP:4298431":
-        description: "SNOMED White blood cell count"
+        description: "SNOMED White blood cell count | WBC"
         meaning: OMOP:4298431
       "OMOP:3015183":
         description: "LOINC Erythrocyte sedimentation rate [Velocity] in Red Blood Cells | Erythrocyte sedimentation rate"
@@ -4403,46 +4403,46 @@ enums:
         description: "SNOMED Plasma total cholesterol level"
         meaning: OMOP:4190897
       "OMOP:46235897":
-        description: "LOINC Albumin/Creatinine [Ratio] in 24 hour Urine"
+        description: "LOINC Albumin/Creatinine [Ratio] in 24 hour Urine | uACR"
         meaning: OMOP:46235897
       "OMOP:44811087":
         description: "SNOMED FVC post bronchodilator percentage change | FVC (forced vital capacity) post bronchodilator percentage change"
         meaning: OMOP:44811087
       "OMOP:44813037":
-        description: "SNOMED Forced expired volume in 1 second percentage change"
+        description: "SNOMED Forced expired volume in 1 second percentage change post bronchodilator | FEV1"
         meaning: OMOP:44813037
       "OMOP:42868473":
-        description: "LOINC FEV1/FVC percent change"
+        description: "LOINC FEV1/FVC percent change post bronchodilator"
         meaning: OMOP:42868473
       "OBA:2100046":
-        description: "8-epi-prostaglandin F2alpha amount in urine | The amount of a 8-epi-prostaglandin F2alpha when measured in urine."
+        description: "8-epi-prostaglandin F2alpha amount in urine | The amount of a 8-epi-prostaglandin F2alpha when measured in urine. | 8-epi-PGF2a"
         meaning: OBA:2100046
       "OBA:2100055":
-        description: "amount of 1-alkyl-2-acetylglycerophosphocholine esterase activity in blood | The amount of a 1-alkyl-2-acetylglycerophosphocholine esterase activity when measured in blood."
+        description: "amount of 1-alkyl-2-acetylglycerophosphocholine esterase activity in blood | The amount of a 1-alkyl-2-acetylglycerophosphocholine esterase activity when measured in blood. | LP-PLA2"
         meaning: OBA:2100055
       "OBA:2100053":
-        description: "albumin to creatinine ratio in urine | A compound attribute that is the ratio of urine albumin amount to urine creatinine amount."
+        description: "albumin to creatinine ratio in urine | A compound attribute that is the ratio of urine albumin amount to urine creatinine amount. | uACR"
         meaning: OBA:2100053
       "OBA:2060178":
         description: "amount of albumin in blood | The amount of a albumin when measured in blood."
         meaning: OBA:2060178
       "OBA:VT0001573":
-        description: "blood alanine transaminase amount | The amount of a alanine aminotransferase when measured in blood."
+        description: "blood alanine transaminase amount | The amount of a alanine aminotransferase when measured in blood. | ALT SGPT"
         meaning: OBA:VT0001573
       "OBA:2100047":
-        description: "aspartate aminotransferase (human) amount in blood | The amount of a aspartate aminotransferase (human) when measured in blood."
+        description: "aspartate aminotransferase (human) amount in blood | The amount of a aspartate aminotransferase (human) when measured in blood. | AST SGOT"
         meaning: OBA:2100047
       "OBA:2100274":
-        description: "natriuretic peptides B amount in blood | The amount of a natriuretic peptides B when measured in blood."
+        description: "natriuretic peptides B amount in blood | The amount of a natriuretic peptides B when measured in blood. | BNP"
         meaning: OBA:2100274
       "OBA:2100054":
-        description: "urea nitrogen to creatinine ratio in blood | A compound attribute that is the ratio of blood urea nitrogen amount to blood creatinine amount."
+        description: "urea nitrogen to creatinine ratio in blood | A compound attribute that is the ratio of blood urea nitrogen amount to blood creatinine amount. | BUN creatinine ratio"
         meaning: OBA:2100054
       "NCIT:C80425":
-        description: "Coronary Calcium Score | A quantitative value that is the compilation of assessed size and densities of calcium deposits throughout the coronary tree."
+        description: "Coronary Calcium Score | A quantitative value that is the compilation of assessed size and densities of calcium deposits throughout the coronary tree. | CAC score"
         meaning: NCIT:C80425
       "OBA:2090004":
-        description: "carotid artery intima-media region thickness | The thickness of a carotid artery intima-media region."
+        description: "carotid artery intima-media region thickness | The thickness of a carotid artery intima-media region. | Carotid IMT"
         meaning: OBA:2090004
       "OBA:2050108":
         description: "carotid artery thickness | The thickness of a carotid artery segment."
@@ -4454,7 +4454,7 @@ enums:
         description: "D-dimer (human) amount in blood | The amount of a D-dimer (human) when measured in blood."
         meaning: OBA:2100048
       "NCIT:C110935":
-        description: "Estimated Glomerular Filtration Rate | A laboratory test that estimates kidney function. It is calculated using an individual's serum creatinine measurement, age, sex, and race. Actual results are reported when the estimated glomerular filtration rate is less than 60 ml/min."
+        description: "Estimated Glomerular Filtration Rate | A laboratory test that estimates kidney function. It is calculated using an individual's serum creatinine measurement, age, sex, and race. Actual results are reported when the estimated glomerular filtration rate is less than 60 ml/min. | eGFR"
         meaning: NCIT:C110935
       "OBA:2050626":
         description: "level of coagulation factor VII in blood | The amount of a coagulation factor VII when measured in blood."
@@ -4463,37 +4463,37 @@ enums:
         description: "level of glucose in blood during fasting | The amount of a glucose when measured in blood during fasting."
         meaning: OBA:2090000
       "CMO:0000241":
-        description: "forced expiratory volume to forced vital capacity ratio | The comparison of forced expiratory volume to forced vital capacity expressed as ratio or percentage."
+        description: "forced expiratory volume to forced vital capacity ratio | The comparison of forced expiratory volume to forced vital capacity expressed as ratio or percentage. | FEV1/FVC"
         meaning: CMO:0000241
       "CMO:0000251":
         description: "forced vital capacity (FVC) | The volume of air that can be forcibly expelled from a maximally inflated lung."
         meaning: CMO:0000251
       "OBA:2045397":
-        description: "serum high-density lipoprotein cholesterol level | The amount of a high-density lipoprotein cholesterol when measured in blood serum."
+        description: "serum high-density lipoprotein cholesterol level | The amount of a high-density lipoprotein (HDL) cholesterol when measured in blood serum."
         meaning: OBA:2045397
       "OBA:2100049":
-        description: "hemoglobin A1c amount in blood | The amount of a hemoglobin A1c when measured in blood."
+        description: "hemoglobin A1c amount in blood | The amount of a hemoglobin A1c when measured in blood. | HbA1c"
         meaning: OBA:2100049
       "OBA:2090001":
         description: "level of insulin in blood during fasting | The amount of a insulin when measured in blood during fasting."
         meaning: OBA:2090001
       "OBA:VT0008640":
-        description: "blood interleukin-1 beta amount | The amount of a interleukin-1 beta when measured in blood."
+        description: "blood interleukin-1 beta amount | The amount of a interleukin-1 beta when measured in blood. | IL1b"
         meaning: OBA:VT0008640
       "OBA:VT0008590":
-        description: "blood interleukin-10 amount | The amount of a interleukin-10 when measured in blood."
+        description: "blood interleukin-10 amount | The amount of a interleukin-10 when measured in blood. | IL10"
         meaning: OBA:VT0008590
       "OBA:2045398":
-        description: "serum low-density lipoprotein cholesterol level | The amount of a low-density lipoprotein cholesterol when measured in blood serum."
+        description: "serum low-density lipoprotein cholesterol level | The amount of a low-density lipoprotein (LDL) cholesterol when measured in blood serum."
         meaning: OBA:2045398
       "OBA:2045349":
         description: "NT pro BNP | natriuretic peptides B proteolytic cleavage product level | The amount of a natriuretic peptides B proteolytic cleavage product when measured in anatomical entity."
         meaning: OBA:2045349
       "OBA:2050271":
-        description: "tumor necrosis factor receptor superfamily member 11B amount | The amount of a tumor necrosis factor receptor superfamily member 11B when measured in anatomical entity."
+        description: "tumor necrosis factor receptor superfamily member 11B amount | The amount of a tumor necrosis factor receptor superfamily member 11B when measured in anatomical entity. | OPG osteoprotegerin | TNFRSF11B"
         meaning: OBA:2050271
       "OBA:VT0003179":
-        description: "platelet quantity | The amount of a platelet."
+        description: "platelet quantity | The amount of platelets."
         meaning: OBA:VT0003179
       "CMO:0000233":
         description: "PR interval | Time between the beginning of the P wave to the beginning of the QRS complex, reflects the time the electrical impulse takes to travel from the sinus node through the AV node and entering the ventricles, used as an estimate of AV node function."
@@ -4508,17 +4508,16 @@ enums:
         description: "dietary sodium intake measurement | Quantification of dietary sodium intake."
         meaning: EFO:0020080
       "OBA:VT0000183":
-        description: "blood pressure trait | The pressure of a blood."
+        description: "blood pressure trait | The pressure of blood."
         meaning: OBA:VT0000183
       "OBA:2100051":
-        description: "troponin complex amount in blood | The amount of a troponin complex when measured in blood."
+        description: "troponin complex amount in blood | The amount of a troponin complex when measured in blood. | troponin all types"
         meaning: OBA:2100051
       "OBA:2100052":
         description: "waist to hip ratio | A compound attribute that is the ratio of waist circumference to hip circumference."
         meaning: OBA:2100052
-
       "OMOP:3013682":
-        description: "LOINC Urea nitrogen [Mass/volume] in Serum or Plasma"
+        description: "LOINC Urea nitrogen [Mass/volume] in Serum or Plasma | BUN"
         meaning: OMOP:3013682
       "OMOP:3003205":
         description: "LOINC Brachial artery Systolic blood pressure"

--- a/src/bdchm/schema/bdchm.yaml
+++ b/src/bdchm/schema/bdchm.yaml
@@ -25,6 +25,9 @@ prefixes:
   MMO: http://purl.obolibrary.org/obo/MMO_
   BAO: http://www.bioassayontology.org/bao#BAO_
   UBERON: http://purl.obolibrary.org/obo/UBERON_
+  NCIT: http://purl.obolibrary.org/obo/NCIT_
+  CMO: http://purl.obolibrary.org/obo/CMO_
+  EFO: http://www.ebi.ac.uk/efo/EFO_
 
 default_prefix: bdchm
 default_range: string
@@ -3784,252 +3787,748 @@ enums:
 
   MeasurementObservationTypeEnum:
     description: Values describing the types of MeasurementObservations.
+    pv_formula: CURIE
     permissible_values:
-      ALBUMIN_IN_BLOOD: 
-        meaning: OBA:2050068 #Albumin in blood
-      ALPHA-1_ANTITRYPSIN_IN_SERUM:
-        meaning: OBA:2050075 #Alpha-1 antitrypsin in serum
-      ALT_SGPT:   
-        meaning: OBA:2050062 #ALT SGPT
-      BASOPHILS_COUNT:  
-        meaning: OBA:VT0002607  #basophils count
-      BILIRUBIN_UNCONJUGATED_INDIRECT: 
-        meaning: OBA:VT0001569  #Bilirubin Unconjugated Indirect
-      BMI:  
-        meaning: OBA:2045455 #BMI
-      BNP:  
-        meaning: OBA:2045303 #BNP
-      BODY_WEIGHT:   
-        meaning: OBA:VT0001259  #Body weight
-      BUN:  
-        meaning: OBA:VT0005265  #BUN
-      CD40_IN_BLOOD: 
-        meaning: OBA:2052305 #CD40 in blood
-      CHLORIDE_IN_BLOOD:   
-        meaning: OBA:VT0003018  #Chloride in blood
-      CREATININE_IN_BLOOD: 
-        meaning: OBA:2050096 #Creatinine in blood
-      CREATININE_IN_URINE: 
-        meaning: OBA:VT0010540  #Creatinine in urine
-      CYSTATIN_C_IN_BLOOD: 
-        meaning: OBA:2052375 #Cystatin C in blood
-      E-SELECTIN_IN_BLOOD: 
-        meaning: OBA:2052778 #E-selectin in blood
-      EOSINOPHILS_COUNT:   
-        meaning: OBA:VT0002602  #Eosinophils count
-      ERYTHROCYTE_SED_RATE:   
-        meaning: OBA:2045235 #Erythrocyte Sed Rate
-      FACTOR_VII: 
-        meaning: OBA:2041535 #Factor VII
-      FERRITIN:   
-        meaning: OBA:VT0010513  #Ferritin
-      FIBRINOGEN: 
-        meaning: OBA:0000061 #Fibrinogen
-      GFR:  
-        meaning: OBA:0003747 #GFR
-      GLUCOSE_IN_BLOOD: 
-        meaning: OBA:VT0000188  #Glucose in blood
-      HDL:  
-        meaning: OBA:VT0000184  #HDL
-      HEART_RATE: 
-        meaning: OBA:1001087 #Heart rate
-      HEIGHT:  
-        meaning: OBA:VT0001253  #Height
-      HEMATOCRIT: 
-        meaning: OBA:2045381 #Hematocrit
-      HEMOGLOBIN: 
-        meaning: OBA:2060175 #Hemoglobin
-      HIP_CIRCUMFERENCE:   
-        meaning: OBA:1000032 #Hip circumference
-      INSULIN_IN_BLOOD: 
-        meaning: OBA:2060174 #Insulin in blood
-      INTERLEUKIN_6_IN_BLOOD: 
-        meaning: OBA:2052890 #interleukin 6 in blood
-      LACTATE_DEHYDROGENASE_LDH: 
-        meaning: OBA:VT0010477  #Lactate Dehydrogenase LDH
-      LACTATE_IN_BLOOD: 
-        meaning: OBA:VT0010616  #Lactate in blood
-      LDL:  
-        meaning: OBA:VT0000181  #LDL
-      LYMPHOCYTES_COUNT:   
-        meaning: OBA:VT0000717  #Lymphocytes count
-      MCP1_IN_BLOOD: 
-        meaning: OBA:2052436 #MCP1 in blood
-      MEAN_ARTERIAL_PRESSURE: 
-        meaning: OBA:VT2000000  #Mean arterial pressure
-      MEAN_CORPUSCULAR_HEMOGLOBIN:  
-        meaning: OBA:2045301 #mean corpuscular hemoglobin
-      MEAN_CORPUSCULAR_VOLUME:   
-        meaning: OBA:0003460 #mean corpuscular volume
-      MEAN_PLATELET_VOLUME:   
-        meaning: OBA:0003277 #mean platelet volume
-      MMP9_IN_BLOOD: 
-        meaning: OBA:2052397 #MMP9 in blood
-      MYELOPEROXIDASE_IN_BLOOD:  
-        meaning: OBA:2052389 #Myeloperoxidase in blood
-      NEUTROPHILS_COUNT:   
-        meaning: OBA:VT0000222  #Neutrophils count
-      NT_PRO_BNP: 
-        meaning: OBA:2045303 #NT pro BNP
-      P-SELECTIN_IN_BLOOD: 
-        meaning: OBA:2052701 #P-selectin in blood
-      PH_OF_BLOOD:   
-        meaning: OBA:2045409 #pH of blood
-      POTASSIUM_IN_BLOOD:  
-        meaning: OBA:VT0002668  #Potassium in blood
-      QRS_INTERVAL:  
-        meaning: OBA:1001086 #QRS interval
-      RED_BLOOD_CELL_COUNT:   
-        meaning: OBA:VT0001586  #Red blood cell count
-      SLEEP_HOURS:   
-        meaning: OBA:2040171 #Sleep hours
-      SMOKING_STATUS: 
-        meaning: OMOP:4282779 #Smoking status
-      SODIUM_IN_BLOOD:  
-        meaning: OBA:VT0001776  #Sodium in blood
-      SPO2: 
-        meaning: OBA:2045443 #SpO2
-      TEMPERATURE:   
-        meaning: OBA:VT0005535  #Temperature
-      TNFA_IN_BLOOD: 
-        meaning: OBA:2051979 #TNFa in blood
-      TNFA-R1_IN_BLOOD: 
-        meaning: OBA:2051975 #TNFa-R1 in blood
-      TOTAL_CHOLESTEROL_IN_BLOOD:   
-        meaning: OBA:VT0000180  #Total cholesterol in blood
-      TRIGLYCERIDES_IN_BLOOD: 
-        meaning: OBA:VT0002644  #Triglycerides in blood
-      VON_WILLEBRAND_FACTOR:  
-        meaning: OBA:2052741 #von Willebrand factor
-      WAIST_CIRCUMFERENCE: 
-        meaning: OBA:1001085 #Waist circumference
-      WHITE_BLOOD_CELL_COUNT: 
-        meaning: OBA:VT0000217  #White blood cell count
-      ALBUMIN_IN_URINE: 
-        meaning: OBA:VT0002871  #Albumin in urine
-      FACTOR_VIII:   
-        meaning: OBA:2041536 #Factor VIII
-      MONOCYTES_COUNT:  
-        meaning: OBA:VT0000223  #monocytes count
-      ISOPROSTANE_8_EPI_PGF2A:
-        meaning: OMOP:3011888      #isoprostane_8_epi_pgf2a
-      LPPLA2_ACT:
-        meaning: OMOP:36305170     #lppla2_act
-      APNEA_HYPOP_INDEX:
-        meaning: OMOP:37396400     #apnea_hypop_index
-      ALBUMIN_CREATININE:
-        meaning: OMOP:4154347      #albumin_creatinine
-      ALCOHOL_SERVINGS:
-        meaning: OMOP:35609491     #alcohol_servings
-      AST_SGOT:
-        meaning: OMOP:4263457      #ast_sgot
-      BILIRUBIN_CON:
-        meaning: OMOP:44805650     #bilirubin_con
-      BILIRUBIN_TOT:
-        meaning: OMOP:4230543      #bilirubin_tot
-      BUN_CREATININE:
-        meaning: OMOP:4112223      #bun_creatinine
-      CRP:
-        meaning: OMOP:4208414      #crp
-      CAC_SCORE:
-        meaning: OMOP:42872742     #cac_score
-      CAROTID_IMT:
-        meaning: OMOP:4138462      #carotid_imt
-      SMOKING:
-        meaning: OMOP:43054909     #smoking
-      D_DIMER:
-        meaning: OMOP:37393605     #d_dimer
-      BP_DIASTOLIC:
-        meaning: OMOP:4154790      #bp_diastolic
-      EGFR:
-        meaning: OMOP:37208635     #egfr
-      FAST_GLUC_BLD:
-        meaning: OMOP:4156660      #fast_gluc_bld
-      FEV1:
-        meaning: OMOP:4241837      #fev1
-      FEV1_FVC:
-        meaning: OMOP:3011505      #fev1_fvc
-      FEV1_PERCENT_CHANGE:
-        meaning: OMOP:44813037      #fev1_percent_change
-      FRUIT_SERVING:
-        meaning: OMOP:21493059     #fruit_serving
-      FVC:
-        meaning: OMOP:4176265      #fvc
-      HEMO_A1C:
-        meaning: OMOP:4184637      #hemo_a1c
-      ICAM:
-        meaning: OMOP:4284103      #icam
-      IL1_BETA:
-        meaning: OMOP:3001804      #il1_beta
-      IL10:
-        meaning: OMOP:3004578      #il10
-      IL18:
-        meaning: OMOP:3043144      #il18
-      LYMPHO_PCT:
-        meaning: OMOP:37208690     #lympho_pct
-      LPPLA2_MASS:
-        meaning: OMOP:3041450      #lppla2_mass
-      MCHC:
-        meaning: OMOP:37393850     #mchc
-      NEUTRO_PCT:
-        meaning: OMOP:37208698     #neutro_pct
-      OPG:
-        meaning: OMOP:1552124      #opg
-      PLATELET_CT:
-        meaning: OMOP:4267147      #platelet_ct
-      PR_EKG:
-        meaning: OMOP:4274406      #pr_ekg
-      PROCAL:
-        meaning: OMOP:44791466     #procal
-      QT_EKG:
-        meaning: OMOP:4273023      #qt_ekg
-      RDW:
-        meaning: OMOP:37397924     #rdw
-      RESP_RT:
-        meaning: OMOP:4313591      #resp_rt
-      SODIUM_INTAK:
-        meaning: OMOP:606729    #sodium_intak
-      TNFR2:
-        meaning: OMOP:37543055     #tnfr2
-      TROPONIN:
-        meaning: OMOP:4021291      #troponin
-      VEGE_SERVING:
-        meaning: OMOP:37311566      #vege_serving
-      WAIST_HIP:
-        meaning: OMOP:4087501      #waist_hip
-      CESD_SCORE:
-        meaning: OMOP:36303297     #cesd_score
-      FAST_LIPIDS:
-        meaning: OMOP:4150326      #fast_lipids
-      MED_ADHER:
-        meaning: OMOP:4056965      #med_adher
-      MED_USE:
-        meaning: OMOP:3021806      #med_use
-      PACEM_STAT:
-        meaning: OMOP:45772840     #pacem_stat
-      SLP_AP_STAT:
-        meaning: OMOP:313459    #slp_ap_stat
-      BP_SYSTOLIC:
-        meaning: OMOP:4152194      #bp_systolic
-      FVC_PRED:
+
+      "OBA:2050068":
+        description: Albumin in blood
+        meaning: OBA:2050068
+      "OBA:2050075":
+        description: Alpha-1 antitrypsin in serum
+        meaning: OBA:2050075
+      "OBA:2050062":
+        description: ALT SGPT
+        meaning: OBA:2050062
+      "OBA:VT0002607":
+        description: basophils count
+        meaning: OBA:VT0002607
+      "OBA:VT0001569":
+        description: Bilirubin Unconjugated Indirect
+        meaning: OBA:VT0001569
+      "OBA:2045455":
+        description: BMI
+        meaning: OBA:2045455
+      "OBA:2045303":
+        description: BNP
+        meaning: OBA:2045303
+      "OBA:VT0001259":
+        description: Body weight
+        meaning: OBA:VT0001259
+      "OBA:VT0005265":
+        description: BUN
+        meaning: OBA:VT0005265
+      "OBA:2052305":
+        description: CD40 in blood
+        meaning: OBA:2052305
+      "OBA:VT0003018":
+        description: Chloride in blood
+        meaning: OBA:VT0003018
+      "OBA:2050096":
+        description: Creatinine in blood
+        meaning: OBA:2050096
+      "OBA:VT0010540":
+        description: Creatinine in urine
+        meaning: OBA:VT0010540
+      "OBA:2052375":
+        description: Cystatin C in blood
+        meaning: OBA:2052375
+      "OBA:2052778":
+        description: E-selectin in blood
+        meaning: OBA:2052778
+      "OBA:VT0002602":
+        description: Eosinophils count
+        meaning: OBA:VT0002602
+      "OBA:2045235":
+        description: Erythrocyte Sed Rate
+        meaning: OBA:2045235
+      "OBA:2041535":
+        description: Factor VII
+        meaning: OBA:2041535
+      "OBA:VT0010513":
+        description: Ferritin
+        meaning: OBA:VT0010513
+      "OBA:0000061":
+        description: Fibrinogen
+        meaning: OBA:0000061
+      "OBA:0003747":
+        description: GFR
+        meaning: OBA:0003747
+      "OBA:VT0000188":
+        description: Glucose in blood
+        meaning: OBA:VT0000188
+      "OBA:VT0000184":
+        description: HDL
+        meaning: OBA:VT0000184
+      "OBA:1001087":
+        description: Heart rate
+        meaning: OBA:1001087
+      "OBA:VT0001253":
+        description: Height
+        meaning: OBA:VT0001253
+      "OBA:2045381":
+        description: Hematocrit
+        meaning: OBA:2045381
+      "OBA:2060175":
+        description: Hemoglobin
+        meaning: OBA:2060175
+      "OBA:1000032":
+        description: Hip circumference
+        meaning: OBA:1000032
+      "OBA:2060174":
+        description: Insulin in blood
+        meaning: OBA:2060174
+      "OBA:2052890":
+        description: interleukin 6 in blood
+        meaning: OBA:2052890
+      "OBA:VT0010477":
+        description: Lactate Dehydrogenase LDH
+        meaning: OBA:VT0010477
+      "OBA:VT0010616":
+        description: Lactate in blood
+        meaning: OBA:VT0010616
+      "OBA:VT0000181":
+        description: LDL
+        meaning: OBA:VT0000181
+      "OBA:VT0000717":
+        description: Lymphocytes count
+        meaning: OBA:VT0000717
+      "OBA:2052436":
+        description: MCP1 in blood
+        meaning: OBA:2052436
+      "OBA:VT2000000":
+        description: Mean arterial pressure
+        meaning: OBA:VT2000000
+      "OBA:2045301":
+        description: mean corpuscular hemoglobin
+        meaning: OBA:2045301
+      "OBA:0003460":
+        description: mean corpuscular volume
+        meaning: OBA:0003460
+      "OBA:0003277":
+        description: mean platelet volume
+        meaning: OBA:0003277
+      "OBA:2052397":
+        description: MMP9 in blood
+        meaning: OBA:2052397
+      "OBA:2052389":
+        description: Myeloperoxidase in blood
+        meaning: OBA:2052389
+      "OBA:VT0000222":
+        description: Neutrophils count
+        meaning: OBA:VT0000222
+      "OBA:2052701":
+        description: P-selectin in blood
+        meaning: OBA:2052701
+      "OBA:2045409":
+        description: pH of blood
+        meaning: OBA:2045409
+      "OBA:VT0002668":
+        description: Potassium in blood
+        meaning: OBA:VT0002668
+      "OBA:1001086":
+        description: QRS interval
+        meaning: OBA:1001086
+      "OBA:VT0001586":
+        description: Red blood cell count
+        meaning: OBA:VT0001586
+      "OBA:2040171":
+        description: Sleep hours
+        meaning: OBA:2040171
+      "OBA:VT0001776":
+        description: Sodium in blood
+        meaning: OBA:VT0001776
+      "OBA:2045443":
+        description: SpO2
+        meaning: OBA:2045443
+      "OBA:VT0005535":
+        description: Temperature
+        meaning: OBA:VT0005535
+      "OBA:2051979":
+        description: TNFa in blood
+        meaning: OBA:2051979
+      "OBA:2051975":
+        description: TNFa-R1 in blood
+        meaning: OBA:2051975
+      "OBA:VT0000180":
+        description: Total cholesterol in blood
+        meaning: OBA:VT0000180
+      "OBA:VT0002644":
+        description: Triglycerides in blood
+        meaning: OBA:VT0002644
+      "OBA:2052741":
+        description: von Willebrand factor
+        meaning: OBA:2052741
+      "OBA:1001085":
+        description: Waist circumference
+        meaning: OBA:1001085
+      "OBA:VT0000217":
+        description: White blood cell count
+        meaning: OBA:VT0000217
+      "OBA:VT0002871":
+        description: Albumin in urine
+        meaning: OBA:VT0002871
+      "OBA:2041536":
+        description: Factor VIII
+        meaning: OBA:2041536
+      "OBA:VT0000223":
+        description: monocytes count
+        meaning: OBA:VT0000223
+      "OMOP:4282779":
+        description: Smoking status
+        meaning: OMOP:4282779
+      "OMOP:3011888":
+        description: isoprostane_8_epi_pgf2a
+        meaning: OMOP:3011888
+      "OMOP:36305170":
+        description: lppla2_act
+        meaning: OMOP:36305170
+      "OMOP:37396400":
+        description: apnea_hypop_index
+        meaning: OMOP:37396400
+      "OMOP:4154347":
+        description: albumin_creatinine
+        meaning: OMOP:4154347
+      "OMOP:35609491":
+        description: alcohol_servings
+        meaning: OMOP:35609491
+      "OMOP:4263457":
+        description: ast_sgot
+        meaning: OMOP:4263457
+      "OMOP:44805650":
+        description: bilirubin_con
+        meaning: OMOP:44805650
+      "OMOP:4230543":
+        description: bilirubin_tot
+        meaning: OMOP:4230543
+      "OMOP:4112223":
+        description: bun_creatinine
+        meaning: OMOP:4112223
+      "OMOP:4208414":
+        description: crp
+        meaning: OMOP:4208414
+      "OMOP:42872742":
+        description: cac_score
+        meaning: OMOP:42872742
+      "OMOP:4138462":
+        description: carotid_imt
+        meaning: OMOP:4138462
+      "OMOP:43054909":
+        description: smoking
+        meaning: OMOP:43054909
+      "OMOP:37393605":
+        description: d_dimer
+        meaning: OMOP:37393605
+      "OMOP:4154790":
+        description: bp_diastolic
+        meaning: OMOP:4154790
+      "OMOP:37208635":
+        description: egfr
+        meaning: OMOP:37208635
+      "OMOP:4156660":
+        description: fast_gluc_bld
+        meaning: OMOP:4156660
+      "OMOP:4241837":
+        description: fev1
+        meaning: OMOP:4241837
+      "OMOP:3011505":
+        description: fev1_fvc
+        meaning: OMOP:3011505
+      "OMOP:21493059":
+        description: fruit_serving
+        meaning: OMOP:21493059
+      "OMOP:4176265":
+        description: fvc
+        meaning: OMOP:4176265
+      "OMOP:4184637":
+        description: hemo_a1c
+        meaning: OMOP:4184637
+      "OMOP:4284103":
+        description: icam
+        meaning: OMOP:4284103
+      "OMOP:3001804":
+        description: il1_beta
+        meaning: OMOP:3001804
+      "OMOP:3004578":
+        description: il10
+        meaning: OMOP:3004578
+      "OMOP:3043144":
+        description: il18
+        meaning: OMOP:3043144
+      "OMOP:37208690":
+        description: lympho_pct
+        meaning: OMOP:37208690
+      "OMOP:3041450":
+        description: lppla2_mass
+        meaning: OMOP:3041450
+      "OMOP:37393850":
+        description: mchc
+        meaning: OMOP:37393850
+      "OMOP:37208698":
+        description: neutro_pct
+        meaning: OMOP:37208698
+      "OMOP:1552124":
+        description: opg
+        meaning: OMOP:1552124
+      "OMOP:4267147":
+        description: platelet_ct
+        meaning: OMOP:4267147
+      "OMOP:4274406":
+        description: pr_ekg
+        meaning: OMOP:4274406
+      "OMOP:44791466":
+        description: procal
+        meaning: OMOP:44791466
+      "OMOP:4273023":
+        description: qt_ekg
+        meaning: OMOP:4273023
+      "OMOP:37397924":
+        description: rdw
+        meaning: OMOP:37397924
+      "OMOP:4313591":
+        description: resp_rt
+        meaning: OMOP:4313591
+      "OMOP:606729":
+        description: sodium_intak
+        meaning: OMOP:606729
+      "OMOP:37543055":
+        description: tnfr2
+        meaning: OMOP:37543055
+      "OMOP:4021291":
+        description: troponin
+        meaning: OMOP:4021291
+      "OMOP:4042886":
+        description: vege_serving
+        meaning: OMOP:4042886
+      "OMOP:4087501":
+        description: waist_hip
+        meaning: OMOP:4087501
+      "OMOP:36303297":
+        description: cesd_score
+        meaning: OMOP:36303297
+      "OMOP:4150326":
+        description: fast_lipids
+        meaning: OMOP:4150326
+      "OMOP:4056965":
+        description: med_adher
+        meaning: OMOP:4056965
+      "OMOP:3021806":
+        description: med_use
+        meaning: OMOP:3021806
+      "OMOP:45772840":
+        description: pacem_stat
+        meaning: OMOP:45772840
+      "OMOP:313459":
+        description: slp_ap_stat
+        meaning: OMOP:313459
+      "OMOP:4152194":
+        description: bp_systolic
+        meaning: OMOP:4152194
+      "OMOP:3002094":
+        description: FVC predicted
         meaning: OMOP:3002094
-      FEV1_PRED:
+      "OMOP:3022891":
+        description: FEV1 predicted
         meaning: OMOP:3022891
-      FEV1_FVC_PRED:
+      "OMOP:3024594":
+        description: FEV1/FVC predicted
         meaning: OMOP:3024594
-      FEV1_PCT_PRED:
+      "OMOP:3011708":
+        description: FEV1 percent predicted
         meaning: OMOP:3011708
-      FVC_PCT_PRED:
+      "OMOP:3005600":
+        description: FVC percent predicted
         meaning: OMOP:3005600
-      FEV1_FVC_PCT_PRED:
+
+      "OMOP:4196583":
+        description: FEV1/FVC percent predicted
         meaning: OMOP:4196583
-      CAC_VOLUME:
+      "OMOP:2212186":
+        description: "Albumin; serum, plasma or whole blood"
+        meaning: OMOP:2212186
+      "OMOP:2212188":
+        description: "Albumin; urine (eg, microalbumin), quantitative"
+        meaning: OMOP:2212188
+      "OMOP:4146380":
+        description: Alanine aminotransferase measurement
+        meaning: OMOP:4146380
+      "OMOP:3010587":
+        description: Aspartate aminotransferase [Presence] in Serum or Plasma
+        meaning: OMOP:3010587
+      "OMOP:3006315":
+        description: Basophils [#/volume] in Blood
+        meaning: OMOP:3006315
+      "OMOP:3038553":
+        description: Body mass index (BMI) [Ratio]
+        meaning: OMOP:3038553
+      "OMOP:4307029":
+        description: Brain natriuretic peptide measurement
+        meaning: OMOP:4307029
+      "OMOP:3031569":
+        description: Natriuretic peptide B [Mass/volume] in Blood
+        meaning: OMOP:3031569
+      "OMOP:4099154":
+        description: Body weight
+        meaning: OMOP:4099154
+      "OMOP:4017361":
+        description: Blood urea nitrogen measurement
+        meaning: OMOP:4017361
+      "OMOP:4166120":
+        description: Calcium volume
         meaning: OMOP:4166120
-      CAROTID_STEN_LEFT:
+      "OMOP:43020498":
+        description: Left carotid artery stenosis
         meaning: OMOP:43020498
-      CAROTID_STEN_RIGHT:
+      "OMOP:43021859":
+        description: Right carotid artery stenosis
         meaning: OMOP:43021859
-      
+      "OMOP:4209737":
+        description: Lymphocyte antigen CD40
+        meaning: OMOP:4209737
+      "OMOP:4188066":
+        description: Chloride measurement
+        meaning: OMOP:4188066
+      "OMOP:3009024":
+        description: Chloride [Moles/volume] in Specimen
+        meaning: OMOP:3009024
+      "OMOP:35811013":
+        description: Smoking status
+        meaning: OMOP:35811013
+      "OMOP:2212294":
+        description: "Creatinine; blood"
+        meaning: OMOP:2212294
+      "OMOP:3051825":
+        description: Creatinine [Mass/volume] in Blood
+        meaning: OMOP:3051825
+      "OMOP:3016723":
+        description: Creatinine [Mass/volume] in Serum or Plasma
+        meaning: OMOP:3016723
+      "OMOP:3007081":
+        description: Creatinine [Interpretation] in Urine
+        meaning: OMOP:3007081
+      "OMOP:4136584":
+        description: Blood cystatin C measurement
+        meaning: OMOP:4136584
+      "OMOP:37172928":
+        description: D-dimer mass concentration in plasma
+        meaning: OMOP:37172928
+      "OMOP:3010372":
+        description: E selectin [Mass/volume] in Blood
+        meaning: OMOP:3010372
+      "OMOP:4022643":
+        description: Educational achievement
+        meaning: OMOP:4022643
+      "OMOP:3013115":
+        description: Eosinophils [#/volume] in Blood
+        meaning: OMOP:3013115
+      "OMOP:4217630":
+        description: Clotting factor VII assay
+        meaning: OMOP:4217630
+      "OMOP:4148587":
+        description: Factor VIII assay
+        meaning: OMOP:4148587
+      "OMOP:4076114":
+        description: Household income
+        meaning: OMOP:4076114
+      "OMOP:4176561":
+        description: Ferritin measurement
+        meaning: OMOP:4176561
+      "OMOP:3011961":
+        description: Ferritin [Mass/volume] in Blood
+        meaning: OMOP:3011961
+      "OMOP:3001122":
+        description: Ferritin [Mass/volume] in Serum or Plasma
+        meaning: OMOP:3001122
+      "OMOP:4094436":
+        description: Fibrinogen measurement
+        meaning: OMOP:4094436
+      "OMOP:4213477":
+        description: Glomerular filtration rate
+        meaning: OMOP:4213477
+      "OMOP:4149519":
+        description: Glucose measurement
+        meaning: OMOP:4149519
+      "OMOP:4076704":
+        description: High density lipoprotein measurement
+        meaning: OMOP:4076704
+      "OMOP:3027018":
+        description: Heart rate
+        meaning: OMOP:3027018
+      "OMOP:607590":
+        description: Body height
+        meaning: OMOP:607590
+      "OMOP:4151358":
+        description: Hematocrit determination
+        meaning: OMOP:4151358
+      "OMOP:4094758":
+        description: Hemoglobin finding
+        meaning: OMOP:4094758
+      "OMOP:4111665":
+        description: Hip circumference
+        meaning: OMOP:4111665
+      "OMOP:4060873":
+        description: Insulin measurement
+        meaning: OMOP:4060873
+      "OMOP:3022466":
+        description: Insulin [Mass/volume] in Serum or Plasma
+        meaning: OMOP:3022466
+      "OMOP:3011670":
+        description: Insulin [Mass/volume] in Serum or Plasma --12 hours fasting
+        meaning: OMOP:3011670
+      "OMOP:4332015":
+        description: IL-6 assay
+        meaning: OMOP:4332015
+      "OMOP:4012918":
+        description: Lactate dehydrogenase measurement
+        meaning: OMOP:4012918
+      "OMOP:1246795":
+        description: Lactate in blood
+        meaning: OMOP:1246795
+      "OMOP:4331302":
+        description: Low density lipoprotein measurement
+        meaning: OMOP:4331302
+      "OMOP:37208689":
+        description: Lymphocyte count in blood
+        meaning: OMOP:37208689
+      "OMOP:4254663":
+        description: Lymphocyte count
+        meaning: OMOP:4254663
+      "OMOP:1617307":
+        description: Chemokine (C-C motif) ligand 2 [Mass/volume] in Serum or Plasma
+        meaning: OMOP:1617307
+      "OMOP:37168599":
+        description: Mean arterial pressure
+        meaning: OMOP:37168599
+      "OMOP:37398674":
+        description: MCH - Mean corpuscular haemoglobin
+        meaning: OMOP:37398674
+      "OMOP:37393851":
+        description: MCV - Mean corpuscular volume
+        meaning: OMOP:37393851
+      "OMOP:37397923":
+        description: Mean platelet volume
+        meaning: OMOP:37397923
+      "OMOP:40761106":
+        description: Matrix metallopeptidase 9 [Mass/volume] in Blood
+        meaning: OMOP:40761106
+      "OMOP:3001604":
+        description: Monocytes [#/volume] in Blood
+        meaning: OMOP:3001604
+      "OMOP:1988928":
+        description: Myeloperoxidase [Mass/volume] in Serum by Immunoassay
+        meaning: OMOP:1988928
+      "OMOP:37208699":
+        description: Neutrophil count in blood
+        meaning: OMOP:37208699
+      "OMOP:4189511":
+        description: N terminal pro-brain natriuretic peptide level
+        meaning: OMOP:4189511
+      "OMOP:44812009":
+        description: Plasma N-terminal pro B-type natriuretic peptide concentration measurement
+        meaning: OMOP:44812009
+      "OMOP:44812008":
+        description: Serum N-terminal pro B-type natriuretic peptide concentration measurement
+        meaning: OMOP:44812008
+      "OMOP:3007356":
+        description: CD62P cells/cells in Blood
+        meaning: OMOP:3007356
+      "OMOP:4245152":
+        description: Potassium measurement
+        meaning: OMOP:4245152
+      "OMOP:21490733":
+        description: Potassium [Mass/volume] in Blood
+        meaning: OMOP:21490733
+      "OMOP:4273021":
+        description: QRS complex - finding
+        meaning: OMOP:4273021
+      "OMOP:4030871":
+        description: Red blood cell count
+        meaning: OMOP:4030871
+      "OMOP:40768653":
+        description: How many hours do you normally sleep [DI-PAD]
+        meaning: OMOP:40768653
+      "OMOP:4097430":
+        description: Sodium measurement
+        meaning: OMOP:4097430
+      "OMOP:36303745":
+        description: Sodium [Mass/volume] in Specimen
+        meaning: OMOP:36303745
+      "OMOP:4020553":
+        description: Oxygen saturation measurement
+        meaning: OMOP:4020553
+      "OMOP:4302666":
+        description: Body temperature
+        meaning: OMOP:4302666
+      "OMOP:3004282":
+        description: Tumor necrosis factor alpha [Mass/volume] in Serum or Plasma
+        meaning: OMOP:3004282
+      "OMOP:46235360":
+        description: Tumor necrosis factor receptor superfamily member 1A [Mass/volume] in Serum or Plasma
+        meaning: OMOP:46235360
+      "OMOP:4008265":
+        description: Total cholesterol measurement
+        meaning: OMOP:4008265
+      "OMOP:4032789":
+        description: Triglycerides measurement
+        meaning: OMOP:4032789
+      "OMOP:37311566":
+        description: Estimated intake of vegetable servings in 24 hours
+        meaning: OMOP:37311566
+      "OMOP:4252203":
+        description: von Willebrand factor antigen level
+        meaning: OMOP:4252203
+      "OMOP:4172830":
+        description: Waist circumference
+        meaning: OMOP:4172830
+      "OMOP:4298431":
+        description: White blood cell count
+        meaning: OMOP:4298431
+      "OMOP:3015183":
+        description: Erythrocyte sedimentation rate [Velocity] in Red Blood Cells
+        meaning: OMOP:3015183
+      "OMOP:4097822":
+        description: "pH measurement, arterial"
+        meaning: OMOP:4097822
+      "OMOP:4315792":
+        description: "pH measurement, venous"
+        meaning: OMOP:4315792
+      "OMOP:4041720":
+        description: Plasma fasting HDL cholesterol measurement
+        meaning: OMOP:4041720
+      "OMOP:4041721":
+        description: Plasma fasting LDL cholesterol measurement
+        meaning: OMOP:4041721
+      "OMOP:4041722":
+        description: Plasma fasting triglyceride measurement
+        meaning: OMOP:4041722
+      "OMOP:4041557":
+        description: Serum fasting HDL cholesterol measurement
+        meaning: OMOP:4041557
+      "OMOP:4042061":
+        description: Serum fasting LDL cholesterol measurement
+        meaning: OMOP:4042061
+      "OMOP:44791053":
+        description: Serum fasting total cholesterol
+        meaning: OMOP:44791053
+      "OMOP:4042590":
+        description: Serum fasting triglyceride measurement
+        meaning: OMOP:4042590
+      "OMOP:4190897":
+        description: Plasma total cholesterol level
+        meaning: OMOP:4190897
+      "OMOP:46235897":
+        description: Albumin/Creatinine [Ratio] in 24 hour Urine
+        meaning: OMOP:46235897
+      "OMOP:44811087":
+        description: FVC post bronchodilator percentage change
+        meaning: OMOP:44811087
+      "OMOP:44813037":
+        description: Forced expired volume in 1 second percentage change
+        meaning: OMOP:44813037
+      "OMOP:42868473":
+        description: FEV1/FVC percent change
+        meaning: OMOP:42868473
+      "OBA:2100046":
+        description: 8-epi-prostaglandin F2alpha amount in urine
+        meaning: OBA:2100046
+      "OBA:2100055":
+        description: amount of 1-alkyl-2-acetylglycerophosphocholine esterase activity in blood
+        meaning: OBA:2100055
+      "OBA:2100053":
+        description: albumin to creatinine ratio in urine
+        meaning: OBA:2100053
+      "OBA:2060178":
+        description: amount of albumin in blood
+        meaning: OBA:2060178
+      "OBA:VT0001573":
+        description: blood alanine transaminase amount
+        meaning: OBA:VT0001573
+      "OBA:2100047":
+        description: aspartate aminotransferase (human) amount in blood
+        meaning: OBA:2100047
+      "OBA:2100274":
+        description: natriuretic peptides B amount in blood
+        meaning: OBA:2100274
+      "OBA:2100054":
+        description: urea nitrogen to creatinine ratio in blood
+        meaning: OBA:2100054
+      "NCIT:C80425":
+        description: Coronary Calcium Score
+        meaning: NCIT:C80425
+      "OBA:2090004":
+        description: carotid artery intima-media region thickness
+        meaning: OBA:2090004
+      "OBA:2050108":
+        description: carotid artery thickness
+        meaning: OBA:2050108
+      "OBA:VT0005328":
+        description: blood creatinine amount
+        meaning: OBA:VT0005328
+      "OBA:2100048":
+        description: D-dimer (human) amount in blood
+        meaning: OBA:2100048
+      "NCIT:C110935":
+        description: Estimated Glomerular Filtration Rate
+        meaning: NCIT:C110935
+      "OBA:2050626":
+        description: level of coagulation factor VII in blood
+        meaning: OBA:2050626
+      "OBA:2090000":
+        description: level of glucose in blood during fasting
+        meaning: OBA:2090000
+      "CMO:0000241":
+        description: forced expiratory volume to forced vital capacity ratio
+        meaning: CMO:0000241
+      "CMO:0000251":
+        description: forced vital capacity (FVC)
+        meaning: CMO:0000251
+      "OBA:2045397":
+        description: serum high-density lipoprotein cholesterol level
+        meaning: OBA:2045397
+      "OBA:2100049":
+        description: hemoglobin A1c amount in blood
+        meaning: OBA:2100049
+      "OBA:2090001":
+        description: level of insulin in blood during fasting
+        meaning: OBA:2090001
+      "OBA:VT0008640":
+        description: blood interleukin-1 beta amount
+        meaning: OBA:VT0008640
+      "OBA:VT0008590":
+        description: blood interleukin-10 amount
+        meaning: OBA:VT0008590
+      "OBA:2045398":
+        description: serum low-density lipoprotein cholesterol level
+        meaning: OBA:2045398
+      "OBA:2045349":
+        description: natriuretic peptides B proteolytic cleavage product level
+        meaning: OBA:2045349
+      "OBA:2050271":
+        description: tumor necrosis factor receptor superfamily member 11B amount
+        meaning: OBA:2050271
+      "OBA:VT0003179":
+        description: platelet quantity
+        meaning: OBA:VT0003179
+      "CMO:0000233":
+        description: PR interval
+        meaning: CMO:0000233
+      "CMO:0000235":
+        description: QT interval
+        meaning: CMO:0000235
+      "EFO:0009188":
+        description: Red cell distribution width
+        meaning: EFO:0009188
+      "EFO:0020080":
+        description: dietary sodium intake measurement
+        meaning: EFO:0020080
+      "OBA:VT0000183":
+        description: blood pressure trait
+        meaning: OBA:VT0000183
+      "OBA:2100051":
+        description: troponin complex amount in blood
+        meaning: OBA:2100051
+      "OBA:2100052":
+        description: waist to hip ratio
+        meaning: OBA:2100052
 
   EducationalAttainmentObservationTypeEnum:
     description: Values describing the types of Education Attainment observed in an Observation.

--- a/src/bdchm/schema/bdchm.yaml
+++ b/src/bdchm/schema/bdchm.yaml
@@ -4386,10 +4386,10 @@ enums:
         description: "LOINC Erythrocyte sedimentation rate [Velocity] in Red Blood Cells | Erythrocyte sedimentation rate"
         meaning: OMOP:3015183
       "OMOP:4097822":
-        description: "SNOMED "pH measurement, arterial" | pH measurement, arterial"
+        description: "SNOMED pH measurement, arterial | pH measurement, arterial"
         meaning: OMOP:4097822
       "OMOP:4315792":
-        description: "SNOMED "pH measurement, venous" | pH measurement, venous"
+        description: "SNOMED pH measurement, venous | pH measurement, venous"
         meaning: OMOP:4315792
       "OMOP:4041720":
         description: "SNOMED Plasma fasting HDL cholesterol measurement | Plasma fasting HDL cholesterol measurement"


### PR DESCRIPTION
- Add pv_formula: CURIE to MeasurementObservationTypeEnum
- Replace text-based permissible value keys with quoted CURIE identifiers
- Add description and meaning slots to each permissible value
- Add new OMOP and OBA/NCIT/CMO/EFO entries from mapping spreadsheet
- Add NCIT, CMO, and EFO namespace prefixes

Addresses #244 #249 https://github.com/RTIInternational/NHLBI-BDC-DMC-HV/issues/746 https://github.com/RTIInternational/NHLBI-BDC-DMC-HV/issues/761 https://github.com/RTIInternational/NHLBI-BDC-DMC-HV/issues/768 https://github.com/RTIInternational/NHLBI-BDC-DMC-HV/issues/769 #248 