### PR TITLE
switched qty qlty measure to alpha order

### DIFF
--- a/src/bdchm/schema/bdchm.yaml
+++ b/src/bdchm/schema/bdchm.yaml
@@ -975,19 +975,19 @@ classes:
         multivalued: false
         range: DimensionalObservationSet
         required: false
-      quantity_measure:
-        description: An observation related to the present quantity of a specimen - e.g. its weight, volume, or analyte concentration.
-        comments:
-        - Observations are flexible containers for capturing a specific type of observation/measurement data about an object, along with metadata about how it was generated. The specific type of observation made is captured as data in the Observation object.
-        multivalued: true
-        range: SpecimenQuantityObservation
-        required: false
       quality_measure:
         description: An observation about characteristics of a specimen that are indicative of its quality or suitability for use.
         comments:
         - Observations are flexible containers for capturing a specific type of observation/measurement data about an object, along with metadata about how it was generated. The specific type of observation made is captured as data in the Observation object.
         multivalued: true
         range: SpecimenQualityObservation
+        required: false
+      quantity_measure:
+        description: An observation related to the present quantity of a specimen - e.g. its weight, volume, or analyte concentration.
+        comments:
+        - Observations are flexible containers for capturing a specific type of observation/measurement data about an object, along with metadata about how it was generated. The specific type of observation made is captured as data in the Observation object.
+        multivalued: true
+        range: SpecimenQuantityObservation
         required: false
       cellular_composition_type:
         description: A term describing the type of cell or cellular material comprising a specimen.


### PR DESCRIPTION
to prevent an unnecessary edge crossing in dynamic docs